### PR TITLE
Provide ApplicationContext instead of Config classes

### DIFF
--- a/aws-serverless-java-container-spring/pom.xml
+++ b/aws-serverless-java-container-spring/pom.xml
@@ -45,6 +45,13 @@
             <version>${spring.version}</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.springframework/spring-webmvc -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/commons-codec/commons-codec -->
         <dependency>
             <groupId>commons-codec</groupId>

--- a/aws-serverless-java-container-spring/pom.xml
+++ b/aws-serverless-java-container-spring/pom.xml
@@ -45,11 +45,12 @@
             <version>${spring.version}</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.springframework/spring-webmvc -->
+        <!-- https://mvnrepository.com/artifact/org.springframework/spring-test -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <version>${spring.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/commons-codec/commons-codec -->

--- a/aws-serverless-java-container-spring/src/main/java/com/amazonaws/serverless/proxy/spring/LambdaSpringApplicationInitializer.java
+++ b/aws-serverless-java-container-spring/src/main/java/com/amazonaws/serverless/proxy/spring/LambdaSpringApplicationInitializer.java
@@ -45,6 +45,7 @@ public class LambdaSpringApplicationInitializer implements WebApplicationInitial
 
     // Configuration variables that can be passed in
     private ConfigurableWebApplicationContext applicationContext;
+    private boolean refreshContext;
     private List<ServletContextListener> contextListeners;
 
     // Dynamically instantiated properties
@@ -57,10 +58,12 @@ public class LambdaSpringApplicationInitializer implements WebApplicationInitial
     /**
      * Creates a new instance of the WebApplicationInitializer
      * @param applicationContext A custom ConfigurableWebApplicationContext to be used
+     * @param applicationContext Whether or not to refresh the applicationContext
      */
-    public LambdaSpringApplicationInitializer(ConfigurableWebApplicationContext applicationContext) {
+    public LambdaSpringApplicationInitializer(ConfigurableWebApplicationContext applicationContext, boolean refreshContext) {
         this.contextListeners = new ArrayList<>();
         this.applicationContext = applicationContext;
+        this.refreshContext = refreshContext;
     }
 
     /**
@@ -104,7 +107,11 @@ public class LambdaSpringApplicationInitializer implements WebApplicationInitial
 
         // Register and map the dispatcher servlet
         dispatcherServlet = new DispatcherServlet(applicationContext);
-//        dispatcherServlet.refresh();
+
+        if (refreshContext) {
+            dispatcherServlet.refresh();
+        }
+
         dispatcherServlet.onApplicationEvent(new ContextRefreshedEvent(applicationContext));
         dispatcherServlet.init(dispatcherConfig);
 

--- a/aws-serverless-java-container-spring/src/main/java/com/amazonaws/serverless/proxy/spring/LambdaSpringApplicationInitializer.java
+++ b/aws-serverless-java-container-spring/src/main/java/com/amazonaws/serverless/proxy/spring/LambdaSpringApplicationInitializer.java
@@ -45,7 +45,7 @@ public class LambdaSpringApplicationInitializer implements WebApplicationInitial
 
     // Configuration variables that can be passed in
     private ConfigurableWebApplicationContext applicationContext;
-    private boolean refreshContext;
+    private boolean refreshContext = true;
     private List<ServletContextListener> contextListeners;
 
     // Dynamically instantiated properties
@@ -58,12 +58,10 @@ public class LambdaSpringApplicationInitializer implements WebApplicationInitial
     /**
      * Creates a new instance of the WebApplicationInitializer
      * @param applicationContext A custom ConfigurableWebApplicationContext to be used
-     * @param applicationContext Whether or not to refresh the applicationContext
      */
-    public LambdaSpringApplicationInitializer(ConfigurableWebApplicationContext applicationContext, boolean refreshContext) {
+    public LambdaSpringApplicationInitializer(ConfigurableWebApplicationContext applicationContext) {
         this.contextListeners = new ArrayList<>();
         this.applicationContext = applicationContext;
-        this.refreshContext = refreshContext;
     }
 
     /**
@@ -74,6 +72,10 @@ public class LambdaSpringApplicationInitializer implements WebApplicationInitial
      */
     public void addListener(ServletContextListener listener) {
         contextListeners.add(listener);
+    }
+
+    public void setRefreshContext(boolean refreshContext) {
+        this.refreshContext = refreshContext;
     }
 
     public void dispatch(HttpServletRequest request, HttpServletResponse response)

--- a/aws-serverless-java-container-spring/src/main/java/com/amazonaws/serverless/proxy/spring/SpringLambdacontainerHandler.java
+++ b/aws-serverless-java-container-spring/src/main/java/com/amazonaws/serverless/proxy/spring/SpringLambdacontainerHandler.java
@@ -55,8 +55,7 @@ public class SpringLambdaContainerHandler<RequestType, ResponseType> extends Lam
                 new AwsProxyHttpServletResponseWriter(),
                 new AwsProxySecurityContextWriter(),
                 new AwsProxyExceptionHandler(),
-                applicationContext,
-                true
+                applicationContext
         );
     }
 
@@ -66,15 +65,14 @@ public class SpringLambdaContainerHandler<RequestType, ResponseType> extends Lam
      * @return An initialized instance of the `SpringLambdaContainerHandler`
      * @throws ContainerInitializationException
      */
-    public static SpringLambdaContainerHandler<AwsProxyRequest, AwsProxyResponse> getAwsProxyHandler(ConfigurableWebApplicationContext applicationContext, boolean refresh)
+    public static SpringLambdaContainerHandler<AwsProxyRequest, AwsProxyResponse> getAwsProxyHandler(ConfigurableWebApplicationContext applicationContext)
             throws ContainerInitializationException {
         return new SpringLambdaContainerHandler<>(
                 new AwsProxyHttpServletRequestReader(),
                 new AwsProxyHttpServletResponseWriter(),
                 new AwsProxySecurityContextWriter(),
                 new AwsProxyExceptionHandler(),
-                applicationContext,
-                refresh
+                applicationContext
         );
     }
 
@@ -94,29 +92,11 @@ public class SpringLambdaContainerHandler<RequestType, ResponseType> extends Lam
                                         ConfigurableWebApplicationContext applicationContext)
             throws ContainerInitializationException {
         super(requestReader, responseWriter, securityContextWriter, exceptionHandler);
-        initializer = new LambdaSpringApplicationInitializer(applicationContext, false);
+        initializer = new LambdaSpringApplicationInitializer(applicationContext);
     }
 
-    /**
-     * Creates a new container handler with the given reader and writer objects
-     *
-     * @param requestReader An implementation of `RequestReader`
-     * @param responseWriter An implementation of `ResponseWriter`
-     * @param securityContextWriter An implementation of `SecurityContextWriter`
-     * @param exceptionHandler An implementation of `ExceptionHandler`
-     * @param applicationContext An implementation of `ConfigurableWebApplicationContext`
-     * @param refreshContext Whether or not applicationContext needs to be refreshed
-     * @throws ContainerInitializationException
-     */
-    public SpringLambdaContainerHandler(RequestReader<RequestType, AwsProxyHttpServletRequest> requestReader,
-                                        ResponseWriter<AwsHttpServletResponse, ResponseType> responseWriter,
-                                        SecurityContextWriter<RequestType> securityContextWriter,
-                                        ExceptionHandler<ResponseType> exceptionHandler,
-                                        ConfigurableWebApplicationContext applicationContext,
-                                        boolean refreshContext)
-            throws ContainerInitializationException {
-        super(requestReader, responseWriter, securityContextWriter, exceptionHandler);
-        initializer = new LambdaSpringApplicationInitializer(applicationContext, refreshContext);
+    public void setRefreshContext(boolean refreshContext) {
+        this.initializer.setRefreshContext(refreshContext);
     }
 
     @Override

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/SpringAwsProxyTest.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/SpringAwsProxyTest.java
@@ -1,6 +1,5 @@
 package com.amazonaws.serverless.proxy.spring;
 
-import com.amazonaws.serverless.exceptions.ContainerInitializationException;
 import com.amazonaws.serverless.proxy.internal.model.AwsProxyRequest;
 import com.amazonaws.serverless.proxy.internal.model.AwsProxyResponse;
 import com.amazonaws.serverless.proxy.internal.testutils.AwsProxyRequestBuilder;
@@ -12,36 +11,66 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.codec.binary.Base64;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.context.ConfigurableWebApplicationContext;
 
 import java.io.IOException;
 import java.util.UUID;
 
 import static org.junit.Assert.*;
 
+import com.amazonaws.serverless.proxy.internal.model.AwsProxyRequest;
+import com.amazonaws.serverless.proxy.internal.model.AwsProxyResponse;
+import com.amazonaws.serverless.proxy.internal.testutils.AwsProxyRequestBuilder;
+import com.amazonaws.serverless.proxy.internal.testutils.MockLambdaContext;
+import com.amazonaws.serverless.proxy.spring.echoapp.EchoSpringAppConfig;
+import com.amazonaws.serverless.proxy.spring.echoapp.model.MapResponseModel;
+import com.amazonaws.serverless.proxy.spring.echoapp.model.SingleValueModel;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.codec.binary.Base64;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.context.ConfigurableWebApplicationContext;
 
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {EchoSpringAppConfig.class})
+@WebAppConfiguration
+@TestExecutionListeners(inheritListeners = false, listeners = {DependencyInjectionTestExecutionListener.class})
 public class SpringAwsProxyTest {
-
     private static final String CUSTOM_HEADER_KEY = "x-custom-header";
     private static final String CUSTOM_HEADER_VALUE = "my-custom-value";
     private static final String AUTHORIZER_PRINCIPAL_ID = "test-principal-" + UUID.randomUUID().toString();
 
+    @Autowired
+    private ObjectMapper objectMapper;
 
-    private static ObjectMapper objectMapper = new ObjectMapper();
-    private static SpringLambdaContainerHandler<AwsProxyRequest, AwsProxyResponse> handler = null;
+    @Autowired
+    private MockLambdaContext lambdaContext;
 
-    private static Context lambdaContext = new MockLambdaContext();
-
-    @BeforeClass
-    public static void init() {
-        try {
-            handler = SpringLambdaContainerHandler.getAwsProxyHandler(EchoSpringAppConfig.class);
-        } catch (ContainerInitializationException e) {
-            e.printStackTrace();
-            fail();
-        }
-    }
+    @Autowired
+    private SpringLambdaContainerHandler<AwsProxyRequest, AwsProxyResponse> handler;
 
     @Test
     public void headers_getHeaders_echo() {
@@ -188,3 +217,4 @@ public class SpringAwsProxyTest {
         }
     }
 }
+

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/EchoSpringAppConfig.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/EchoSpringAppConfig.java
@@ -1,9 +1,37 @@
 package com.amazonaws.serverless.proxy.spring.echoapp;
 
+import com.amazonaws.serverless.exceptions.ContainerInitializationException;
+import com.amazonaws.serverless.proxy.internal.testutils.MockLambdaContext;
+import com.amazonaws.serverless.proxy.spring.LambdaSpringApplicationInitializer;
+import com.amazonaws.serverless.proxy.spring.SpringLambdaContainerHandler;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.ConfigurableWebApplicationContext;
 
 @Configuration
 @ComponentScan("com.amazonaws.serverless.proxy.spring.echoapp")
 public class EchoSpringAppConfig {
+
+    @Autowired
+    private ConfigurableWebApplicationContext applicationContext;
+
+    @Bean
+    public SpringLambdaContainerHandler springLambdaContainerHandler() throws ContainerInitializationException {
+        return SpringLambdaContainerHandler.getAwsProxyHandler(applicationContext);
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
+    @Bean
+    public MockLambdaContext lambdaContext() {
+        return new MockLambdaContext();
+    }
+
 }

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/EchoSpringAppConfig.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/EchoSpringAppConfig.java
@@ -21,7 +21,9 @@ public class EchoSpringAppConfig {
 
     @Bean
     public SpringLambdaContainerHandler springLambdaContainerHandler() throws ContainerInitializationException {
-        return SpringLambdaContainerHandler.getAwsProxyHandler(applicationContext, false);
+        SpringLambdaContainerHandler handler = SpringLambdaContainerHandler.getAwsProxyHandler(applicationContext);
+        handler.setRefreshContext(false);
+        return handler;
     }
 
     @Bean

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/EchoSpringAppConfig.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/EchoSpringAppConfig.java
@@ -21,7 +21,7 @@ public class EchoSpringAppConfig {
 
     @Bean
     public SpringLambdaContainerHandler springLambdaContainerHandler() throws ContainerInitializationException {
-        return SpringLambdaContainerHandler.getAwsProxyHandler(applicationContext);
+        return SpringLambdaContainerHandler.getAwsProxyHandler(applicationContext, false);
     }
 
     @Bean


### PR DESCRIPTION
Added ability to provide custom ApplicationContext. For Spring testing, made objects that can potentially be shared by multiple tests classes and methods beans.