### PR TITLE
Fix NPE for null in the query parameters

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
@@ -529,7 +529,10 @@ public class AwsProxyHttpServletRequest
     @Override
     public Enumeration<String> getParameterNames() {
         List<String> paramNames = new ArrayList<>();
-        paramNames.addAll(request.getQueryStringParameters().keySet());
+        Map<String, String> queryStringParameters = request.getQueryStringParameters();
+        if (queryStringParameters != null) {
+            paramNames.addAll(queryStringParameters.keySet());
+        }
         paramNames.addAll(urlEncodedFormParameters.keySet());
         return Collections.enumeration(paramNames);
     }
@@ -567,13 +570,16 @@ public class AwsProxyHttpServletRequest
             params = new HashMap<>();
         }
 
-        for (Map.Entry<String, String> entry : request.getQueryStringParameters().entrySet()) {
-            if (params.containsKey(entry.getKey())) {
-                params.get(entry.getKey()).add(entry.getValue());
-            } else {
-                List<String> valueList = new ArrayList<>();
-                valueList.add(entry.getValue());
-                params.put(entry.getKey(), valueList);
+        Map<String, String> queryStringParameters = request.getQueryStringParameters();
+        if (queryStringParameters != null) {
+            for (Map.Entry<String, String> entry : queryStringParameters.entrySet()) {
+                if (params.containsKey(entry.getKey())) {
+                    params.get(entry.getKey()).add(entry.getValue());
+                } else {
+                    List<String> valueList = new ArrayList<>();
+                    valueList.add(entry.getValue());
+                    params.put(entry.getKey(), valueList);
+                }
             }
         }
 
@@ -780,13 +786,14 @@ public class AwsProxyHttpServletRequest
 
 
     private String getQueryStringParameterCaseInsensitive(String key) {
-        if (request.getQueryStringParameters() == null) {
+        Map<String, String> queryStringParameters = request.getQueryStringParameters();
+        if (queryStringParameters == null) {
             return null;
         }
 
-        for (String requestParamKey : request.getQueryStringParameters().keySet()) {
+        for (String requestParamKey : queryStringParameters.keySet()) {
             if (key.toLowerCase().equals(requestParamKey.toLowerCase())) {
-                return request.getQueryStringParameters().get(requestParamKey);
+                return queryStringParameters.get(requestParamKey);
             }
         }
         return null;

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
@@ -529,9 +529,8 @@ public class AwsProxyHttpServletRequest
     @Override
     public Enumeration<String> getParameterNames() {
         List<String> paramNames = new ArrayList<>();
-        Map<String, String> queryStringParameters = request.getQueryStringParameters();
-        if (queryStringParameters != null) {
-            paramNames.addAll(queryStringParameters.keySet());
+        if (request.getQueryStringParameters() != null) {
+            paramNames.addAll(request.getQueryStringParameters().keySet());
         }
         paramNames.addAll(urlEncodedFormParameters.keySet());
         return Collections.enumeration(paramNames);
@@ -570,9 +569,8 @@ public class AwsProxyHttpServletRequest
             params = new HashMap<>();
         }
 
-        Map<String, String> queryStringParameters = request.getQueryStringParameters();
-        if (queryStringParameters != null) {
-            for (Map.Entry<String, String> entry : queryStringParameters.entrySet()) {
+        if (request.getQueryStringParameters() != null) {
+            for (Map.Entry<String, String> entry : request.getQueryStringParameters().entrySet()) {
                 if (params.containsKey(entry.getKey())) {
                     params.get(entry.getKey()).add(entry.getValue());
                 } else {
@@ -786,14 +784,13 @@ public class AwsProxyHttpServletRequest
 
 
     private String getQueryStringParameterCaseInsensitive(String key) {
-        Map<String, String> queryStringParameters = request.getQueryStringParameters();
-        if (queryStringParameters == null) {
+        if (request.getQueryStringParameters() == null) {
             return null;
         }
 
-        for (String requestParamKey : queryStringParameters.keySet()) {
+        for (String requestParamKey : request.getQueryStringParameters().keySet()) {
             if (key.toLowerCase().equals(requestParamKey.toLowerCase())) {
-                return queryStringParameters.get(requestParamKey);
+                return request.getQueryStringParameters().get(requestParamKey);
             }
         }
         return null;

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestTest.java
@@ -8,6 +8,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
 import static org.junit.Assert.*;
 
 public class AwsProxyHttpServletRequestTest {
@@ -38,6 +42,16 @@ public class AwsProxyHttpServletRequestTest {
             .cookie(FORM_PARAM_TEST, FORM_PARAM_NAME_VALUE).build();
     private static final AwsProxyRequest REQUEST_MALFORMED_COOKIE = new AwsProxyRequestBuilder("/hello", "GET")
             .header(HttpHeaders.COOKIE, QUERY_STRING_NAME_VALUE).build();
+
+    private static final AwsProxyRequest REQUEST_NULL_QUERY_STRING;
+    static {
+        AwsProxyRequest awsProxyRequest = new AwsProxyRequestBuilder("/hello", "GET").build();
+        awsProxyRequest.setQueryStringParameters(null);
+        REQUEST_NULL_QUERY_STRING = awsProxyRequest;
+    }
+
+    private static final AwsProxyRequest REQUEST_QUERY = new AwsProxyRequestBuilder("/hello", "POST")
+            .queryString(FORM_PARAM_NAME, QUERY_STRING_NAME_VALUE).build();
 
 
     @Test
@@ -130,5 +144,37 @@ public class AwsProxyHttpServletRequestTest {
         assertNotNull(request);
         assertNotNull(request.getCookies());
         assertEquals(0, request.getCookies().length);
+    }
+
+    @Test
+    public void queryParameters_getParameterMap_null() {
+        HttpServletRequest request = new AwsProxyHttpServletRequest(REQUEST_NULL_QUERY_STRING, null, null);
+        assertNotNull(request);
+        assertEquals(0, request.getParameterMap().size());
+    }
+
+    @Test
+    public void queryParameters_getParameterMap_nonNull() {
+        HttpServletRequest request = new AwsProxyHttpServletRequest(REQUEST_QUERY, null, null);
+        assertNotNull(request);
+        assertEquals(1, request.getParameterMap().size());
+        assertEquals(QUERY_STRING_NAME_VALUE, request.getParameterMap().get(FORM_PARAM_NAME)[0]);
+    }
+
+    @Test
+    public void queryParameters_getParameterNames_null() {
+        HttpServletRequest request = new AwsProxyHttpServletRequest(REQUEST_NULL_QUERY_STRING, null, null);
+        List<String> parameterNames = Collections.list(request.getParameterNames());
+        assertNotNull(request);
+        assertEquals(0, parameterNames.size());
+    }
+
+    @Test
+    public void queryParameters_getParameterNames_nonNull() {
+        HttpServletRequest request = new AwsProxyHttpServletRequest(REQUEST_QUERY, null, null);
+        List<String> parameterNames = Collections.list(request.getParameterNames());
+        assertNotNull(request);
+        assertEquals(1, parameterNames.size());
+        assertTrue(parameterNames.contains(FORM_PARAM_NAME));
     }
 }


### PR DESCRIPTION
I've tried to use the Spring EchoApp in the real AWS Lambda and the `/echo/query-string` GET-request was failed for non-set query parameters. It happened because in this case `AwsProxyRequest.queryStringParameters` remains uninitialized.