### PR TITLE
Implement HttpServletRequest.getRequestURL()

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/model/AwsProxyRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/model/AwsProxyRequest.java
@@ -155,4 +155,20 @@ public class AwsProxyRequest {
     public void setBase64Encoded(boolean base64Encoded) {
         isBase64Encoded = base64Encoded;
     }
+
+    @Override
+    public String toString() {
+        return "AwsProxyRequest{" +
+                "body='" + body + '\'' +
+                ", resource='" + resource + '\'' +
+                ", requestContext=" + requestContext +
+                ", queryStringParameters=" + queryStringParameters +
+                ", headers=" + headers +
+                ", pathParameters=" + pathParameters +
+                ", httpMethod='" + httpMethod + '\'' +
+                ", stageVariables=" + stageVariables +
+                ", path='" + path + '\'' +
+                ", isBase64Encoded=" + isBase64Encoded +
+                '}';
+    }
 }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/testutils/AwsProxyRequestBuilder.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/testutils/AwsProxyRequestBuilder.java
@@ -68,6 +68,9 @@ public class AwsProxyRequestBuilder {
         return this;
     }
 
+//    public AwsProxyRequestBuilder schemeAndHost(String scheme) {
+//        this.request.getRequestContext().
+//    }
 
     public AwsProxyRequestBuilder path(String path) {
         this.request.setPath(path);

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/SpringAwsProxyTest.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/SpringAwsProxyTest.java
@@ -187,6 +187,28 @@ public class SpringAwsProxyTest {
         assertEquals(200, output.getStatusCode());
     }
 
+    @Test
+    public void request_requestURI() {
+        AwsProxyRequest request = new AwsProxyRequestBuilder("/echo/request-URI", "GET")
+                .build();
+
+        AwsProxyResponse output = handler.proxy(request, lambdaContext);
+        assertEquals(200, output.getStatusCode());
+
+        validateSingleValueModel(output, "/echo/request-URI");
+    }
+
+    @Test
+    public void request_requestURL() {
+        AwsProxyRequest request = new AwsProxyRequestBuilder("/echo/request-URL", "GET")
+                .build();
+
+        AwsProxyResponse output = handler.proxy(request, lambdaContext);
+        assertEquals(200, output.getStatusCode());
+
+//        validateSingleValueModel(output, "/echo/request-URI");
+    }
+
     private void validateMapResponseModel(AwsProxyResponse output) {
         try {
             MapResponseModel response = objectMapper.readValue(output.getBody(), MapResponseModel.class);

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/EchoResource.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/EchoResource.java
@@ -83,4 +83,20 @@ public class EchoResource {
 
         return new ResponseEntity<byte[]>(b, HttpStatus.OK);
     }
+
+    @RequestMapping(path = "/request-URI", method = RequestMethod.GET)
+    public SingleValueModel echoRequestURI(HttpServletRequest request) {
+        SingleValueModel valueModel = new SingleValueModel();
+        valueModel.setValue(request.getRequestURI());
+
+        return valueModel;
+    }
+
+    @RequestMapping(path = "/request-URL", method = RequestMethod.GET)
+    public SingleValueModel echoRequestURL(HttpServletRequest request) {
+        SingleValueModel valueModel = new SingleValueModel();
+        valueModel.setValue(request.getRequestURL().toString());
+
+        return valueModel;
+    }
 }


### PR DESCRIPTION
Implementing `getRequestURL()` on the HttpServletRequest object addresses https://github.com/awslabs/aws-serverless-java-container/issues/10.  In the process, I also adjusted the following methods, which all contribute to `getRequestURL()`

* getServerName()
* getServer/LocalPort()
* getContextPath()

Tests added and AwsProxyRequestBuilder adjusted