### PR TITLE
Servlet filters support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ public String echoServletHeaders(@Context HttpServletRequest context) {
 You can register [`Filter`](https://docs.oracle.com/javaee/7/api/javax/servlet/Filter.html) implementations by implementing a `StartupsHandler` as defined in the `AwsLambdaServletContainerHandler` class. The `onStartup` methods receives a reference to the current `ServletContext`.
 
 ```java
-handler.setStartupHandler(c -> {
+handler.onStartup(c -> {
     FilterRegistration.Dynamic registration = c.addFilter("CustomHeaderFilter", CustomHeaderFilter.class);
     // update the registration to map to a path
     registration.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/*");

--- a/README.md
+++ b/README.md
@@ -138,3 +138,15 @@ public String echoServletHeaders(@Context HttpServletRequest context) {
     return "servlet";
 }
 ```
+
+## Servlet Filters
+You can register [`Filter`](https://docs.oracle.com/javaee/7/api/javax/servlet/Filter.html) implementations by implementing a `StartupsHandler` as defined in the `AwsLambdaServletContainerHandler` class. The `onStartup` methods receives a reference to the current `ServletContext`.
+
+```java
+handler.setStartupHandler(c -> {
+    FilterRegistration.Dynamic registration = c.addFilter("CustomHeaderFilter", CustomHeaderFilter.class);
+    // update the registration to map to a path
+    registration.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/*");
+    // servlet name mappings are disabled and will throw an exception
+});
+```

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/LambdaContainerHandler.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/LambdaContainerHandler.java
@@ -31,6 +31,12 @@ import java.util.concurrent.CountDownLatch;
 public abstract class LambdaContainerHandler<RequestType, ResponseType, ContainerRequestType, ContainerResponseType> {
 
     //-------------------------------------------------------------
+    // Constants
+    //-------------------------------------------------------------
+
+    public static final String SERVER_INFO = "aws-serverless-java-container";
+
+    //-------------------------------------------------------------
     // Variables - Private
     //-------------------------------------------------------------
 

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsFilterChainManager.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsFilterChainManager.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.serverless.proxy.internal.servlet;
+
+import java.util.Map;
+
+/**
+ * This implementation of the <code>FilterChainManager</code> object uses the <code>AwsServletContext</code> object
+ * to extract a list of <code>FilterHolder</code>s
+ */
+public class AwsFilterChainManager extends FilterChainManager<AwsServletContext> {
+
+    //-------------------------------------------------------------
+    // Constructors
+    //-------------------------------------------------------------
+
+    /**
+     * Creates a new FilterChainManager for the given servlet context
+     * @param context An initialized AwsServletContext object
+     */
+    AwsFilterChainManager(AwsServletContext context) {
+        super(context);
+    }
+
+    //-------------------------------------------------------------
+    // Implementation - FilterChainManager
+    //-------------------------------------------------------------
+
+    /**
+     * Returns the filter holders stored in the <code>AwsServletContext</code> object
+     * @return The map of filter holders
+     */
+    protected Map<String, FilterHolder> getFilterHolders() {
+        return servletContext.getFilterHolders();
+    }
+}

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
@@ -31,6 +31,7 @@ import java.util.*;
  * the utility methods
  */
 public abstract class AwsHttpServletRequest implements HttpServletRequest {
+
     //-------------------------------------------------------------
     // Constants
     //-------------------------------------------------------------
@@ -46,6 +47,7 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
     // information from anywhere else
     static final String CF_PROTOCOL_HEADER_NAME = "CloudFront-Forwarded-Proto";
 
+
     //-------------------------------------------------------------
     // Variables - Private
     //-------------------------------------------------------------
@@ -53,6 +55,7 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
     private Context lamdaContext;
     private DispatcherType dispatcherType;
     private Map<String, Object> attributes;
+
 
     //-------------------------------------------------------------
     // Constructors
@@ -72,96 +75,6 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
     }
 
     //-------------------------------------------------------------
-    // Methods - Protected
-    //-------------------------------------------------------------
-
-    /**
-     * Given the Cookie header value, parses it and creates a Cookie object
-     * @param headerValue The string value of the HTTP Cookie header
-     * @return An array of Cookie objects from the header
-     */
-    protected Cookie[] parseCookies(String headerValue) {
-        List<Cookie> output = new ArrayList<>();
-
-        for (AbstractMap.SimpleEntry<String, String> entry : this.parseHeaderValue(headerValue)) {
-            if (entry.getKey() != null) {
-                output.add(new Cookie(entry.getKey(), entry.getValue()));
-            }
-        }
-        Cookie[] returnValue = new Cookie[output.size()];
-        return output.toArray(returnValue);
-    }
-
-    protected String readPathInfo(String path, String resource) {
-        // TODO: Implement
-        return "/";
-    }
-
-    protected String readPathTranslated(String path) {
-        // TODO: Implement
-        return path;
-    }
-
-    /**
-     * Given a map of key/values query string parameters from API Gateway, creates a query string as it would have
-     * been in the original url.
-     * @param parameters A Map<String, String> of query string parameters
-     * @return The generated query string for the URI
-     */
-    protected String generateQueryString(Map<String, String> parameters) {
-        String params = null;
-        if (parameters != null && parameters.size() > 0) {
-            params = "";
-            for (String key : parameters.keySet()) {
-                String separator = params.equals("") ? "?" : "&";
-                String queryStringKey = key;
-                String queryStringValue = parameters.get(key);
-                try {
-                    // if they were URLDecoded along the way we should re-encode them for the URI
-                    if (!URLEncoder.encode(queryStringKey, StandardCharsets.UTF_8.name()).equals(key)) {
-                        queryStringKey = URLEncoder.encode(queryStringKey, StandardCharsets.UTF_8.name());
-                    }
-                    if (!URLEncoder.encode(queryStringValue, StandardCharsets.UTF_8.name()).equals(queryStringValue)) {
-                        queryStringValue = URLEncoder.encode(queryStringValue, StandardCharsets.UTF_8.name());
-                    }
-                } catch (UnsupportedEncodingException e) {
-                    // TODO: Should we stop for the exception?
-                    lamdaContext.getLogger().log("Could not URLEncode: " + queryStringKey);
-                    e.printStackTrace();
-                }
-                params += separator + queryStringKey + "=" + queryStringValue;
-            }
-        }
-
-        return params;
-    }
-
-    /**
-     * Generic method to parse an HTTP header value and split it into a list of key/values for all its components.
-     * When the property in the header does not specify a key the key field in the output pair is null and only the value
-     * is populated. For example, The header <code>Accept: application/json; application/xml</code> will contain two
-     * key value pairs with key null and the value set to application/json and application/xml respectively.
-     *
-     * @param headerContent The string value for the HTTP header
-     * @return A list of SimpleMapEntry objects with all of the possible values for the header.
-     */
-    protected List<AbstractMap.SimpleEntry<String, String>> parseHeaderValue(String headerContent) {
-        List<AbstractMap.SimpleEntry<String, String>> values = new ArrayList<>();
-        if (headerContent != null) {
-            for (String kv : headerContent.split(HEADER_VALUE_SEPARATOR)) {
-                String[] kvSplit = kv.split(HEADER_KEY_VALUE_SEPARATOR);
-
-                if (kvSplit.length != 2) {
-                    values.add(new AbstractMap.SimpleEntry<>(null, kv.trim()));
-                } else {
-                    values.add(new AbstractMap.SimpleEntry<>(kvSplit[0].trim(), kvSplit[1].trim()));
-                }
-            }
-        }
-        return values;
-    }
-
-    //-------------------------------------------------------------
     // Implementation - HttpServletRequest
     //-------------------------------------------------------------
 
@@ -170,6 +83,7 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
         // TODO: Throw not implemented
         return null;
     }
+
 
     @Override
     public HttpSession getSession(boolean b) {
@@ -212,15 +126,35 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
         return false;
     }
 
+
+    //-------------------------------------------------------------
+    // Implementation - ServletRequest
+    //-------------------------------------------------------------
+
+
     @Override
     public Object getAttribute(String s) {
         return attributes.get(s);
     }
 
+
     @Override
     public Enumeration<String> getAttributeNames() {
         return Collections.enumeration(attributes.keySet());
     }
+
+
+    @Override
+    public String getServerName() {
+        return "lambda.amazonaws.com";
+    }
+
+
+    @Override
+    public int getServerPort() {
+        return 0;
+    }
+
 
     @Override
     public void setAttribute(String s, Object o) {
@@ -233,16 +167,6 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
         attributes.remove(s);
     }
 
-    @Override
-    public String getServerName() {
-        return "lambda.amazonaws.com";
-    }
-
-
-    @Override
-    public int getServerPort() {
-        return 0;
-    }
 
     @Override
     public String getLocalName() {
@@ -261,6 +185,13 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
         return 0;
     }
 
+
+    @Override
+    public ServletContext getServletContext() {
+        return AwsServletContext.getInstance(lamdaContext);
+    }
+
+
     @Override
     public boolean isAsyncStarted() {
         return false;
@@ -278,13 +209,104 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
         return null;
     }
 
-    @Override
-    public ServletContext getServletContext() {
-        return AwsServletContext.getInstance(lamdaContext);
-    }
 
     @Override
     public DispatcherType getDispatcherType() {
         return dispatcherType;
+    }
+
+
+    //-------------------------------------------------------------
+    // Methods - Protected
+    //-------------------------------------------------------------
+
+    /**
+     * Given the Cookie header value, parses it and creates a Cookie object
+     * @param headerValue The string value of the HTTP Cookie header
+     * @return An array of Cookie objects from the header
+     */
+    protected Cookie[] parseCookies(String headerValue) {
+        List<Cookie> output = new ArrayList<>();
+
+        for (AbstractMap.SimpleEntry<String, String> entry : this.parseHeaderValue(headerValue)) {
+            if (entry.getKey() != null) {
+                output.add(new Cookie(entry.getKey(), entry.getValue()));
+            }
+        }
+        Cookie[] returnValue = new Cookie[output.size()];
+        return output.toArray(returnValue);
+    }
+
+
+    protected String readPathInfo(String path, String resource) {
+        // TODO: Implement
+        return "/";
+    }
+
+
+    protected String readPathTranslated(String path) {
+        // TODO: Implement
+        return path;
+    }
+
+
+    /**
+     * Given a map of key/values query string parameters from API Gateway, creates a query string as it would have
+     * been in the original url.
+     * @param parameters A Map<String, String> of query string parameters
+     * @return The generated query string for the URI
+     */
+    protected String generateQueryString(Map<String, String> parameters) {
+        String params = null;
+        if (parameters != null && parameters.size() > 0) {
+            params = "";
+            for (String key : parameters.keySet()) {
+                String separator = params.equals("") ? "?" : "&";
+                String queryStringKey = key;
+                String queryStringValue = parameters.get(key);
+                try {
+                    // if they were URLDecoded along the way we should re-encode them for the URI
+                    if (!URLEncoder.encode(queryStringKey, StandardCharsets.UTF_8.name()).equals(key)) {
+                        queryStringKey = URLEncoder.encode(queryStringKey, StandardCharsets.UTF_8.name());
+                    }
+                    if (!URLEncoder.encode(queryStringValue, StandardCharsets.UTF_8.name()).equals(queryStringValue)) {
+                        queryStringValue = URLEncoder.encode(queryStringValue, StandardCharsets.UTF_8.name());
+                    }
+                } catch (UnsupportedEncodingException e) {
+                    // TODO: Should we stop for the exception?
+                    lamdaContext.getLogger().log("Could not URLEncode: " + queryStringKey);
+                    e.printStackTrace();
+                }
+                params += separator + queryStringKey + "=" + queryStringValue;
+            }
+        }
+
+        return params;
+    }
+
+
+    /**
+     * Generic method to parse an HTTP header value and split it into a list of key/values for all its components.
+     * When the property in the header does not specify a key the key field in the output pair is null and only the value
+     * is populated. For example, The header <code>Accept: application/json; application/xml</code> will contain two
+     * key value pairs with key null and the value set to application/json and application/xml respectively.
+     *
+     * @param headerContent The string value for the HTTP header
+     * @return A list of SimpleMapEntry objects with all of the possible values for the header.
+     */
+    protected List<AbstractMap.SimpleEntry<String, String>> parseHeaderValue(String headerContent) {
+        List<AbstractMap.SimpleEntry<String, String>> values = new ArrayList<>();
+        if (headerContent != null) {
+            for (String kv : headerContent.split(HEADER_VALUE_SEPARATOR)) {
+                String[] kvSplit = kv.split(HEADER_KEY_VALUE_SEPARATOR);
+
+                if (kvSplit.length != 2) {
+                    values.add(new AbstractMap.SimpleEntry<>(null, kv.trim()));
+                } else {
+                    values.add(new AbstractMap.SimpleEntry<>(kvSplit[0].trim(), kvSplit[1].trim()));
+                }
+            }
+        }
+        return values;
     }
 }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.serverless.proxy.internal.servlet;
+
+import com.amazonaws.services.lambda.runtime.Context;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
+import javax.servlet.ServletContext;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+/**
+ * Base HttpServletRequest object. This object exposes some utility methods to work with request values such as headers
+ * and query string parameters. New implementations of <code>HttpServletRequest</code> can extend this class to reuse
+ * the utility methods
+ */
+public abstract class AwsHttpServletRequest implements HttpServletRequest {
+    //-------------------------------------------------------------
+    // Constants
+    //-------------------------------------------------------------
+
+    static final String HEADER_KEY_VALUE_SEPARATOR = "=";
+    static final String HEADER_VALUE_SEPARATOR = ";";
+    static final String FORM_DATA_SEPARATOR = "&";
+    static final String DEFAULT_CHARACTER_ENCODING = "UTF-8";
+    static final String HEADER_DATE_FORMAT = "EEE, d MMM yyyy HH:mm:ss z";
+    static final String ENCODING_VALUE_KEY = "charset";
+
+    // We need this to pickup the protocol from the CloudFront header since Lambda doesn't receive this
+    // information from anywhere else
+    static final String CF_PROTOCOL_HEADER_NAME = "CloudFront-Forwarded-Proto";
+
+    //-------------------------------------------------------------
+    // Variables - Private
+    //-------------------------------------------------------------
+
+    private Context lamdaContext;
+    private DispatcherType dispatcherType;
+    private Map<String, Object> attributes;
+
+    //-------------------------------------------------------------
+    // Constructors
+    //-------------------------------------------------------------
+
+    /**
+     * Protected constructors for implemnenting classes. This should be called first with the context received from
+     * AWS Lambda
+     * @param lambdaContext The Lambda function context. This object is used for utility methods such as log
+     */
+    AwsHttpServletRequest(Context lambdaContext) {
+        lamdaContext = lambdaContext;
+        attributes = new HashMap<>();
+
+        // TODO: We are setting this to request by default
+        dispatcherType = DispatcherType.REQUEST;
+    }
+
+    //-------------------------------------------------------------
+    // Methods - Protected
+    //-------------------------------------------------------------
+
+    /**
+     * Given the Cookie header value, parses it and creates a Cookie object
+     * @param headerValue The string value of the HTTP Cookie header
+     * @return An array of Cookie objects from the header
+     */
+    protected Cookie[] parseCookies(String headerValue) {
+        List<Cookie> output = new ArrayList<>();
+
+        for (AbstractMap.SimpleEntry<String, String> entry : this.parseHeaderValue(headerValue)) {
+            if (entry.getKey() != null) {
+                output.add(new Cookie(entry.getKey(), entry.getValue()));
+            }
+        }
+        Cookie[] returnValue = new Cookie[output.size()];
+        return output.toArray(returnValue);
+    }
+
+    protected String readPathInfo(String path, String resource) {
+        // TODO: Implement
+        return "/";
+    }
+
+    protected String readPathTranslated(String path) {
+        // TODO: Implement
+        return path;
+    }
+
+    /**
+     * Given a map of key/values query string parameters from API Gateway, creates a query string as it would have
+     * been in the original url.
+     * @param parameters A Map<String, String> of query string parameters
+     * @return The generated query string for the URI
+     */
+    protected String generateQueryString(Map<String, String> parameters) {
+        String params = null;
+        if (parameters != null && parameters.size() > 0) {
+            params = "";
+            for (String key : parameters.keySet()) {
+                String separator = params.equals("") ? "?" : "&";
+                String queryStringKey = key;
+                String queryStringValue = parameters.get(key);
+                try {
+                    // if they were URLDecoded along the way we should re-encode them for the URI
+                    if (!URLEncoder.encode(queryStringKey, StandardCharsets.UTF_8.name()).equals(key)) {
+                        queryStringKey = URLEncoder.encode(queryStringKey, StandardCharsets.UTF_8.name());
+                    }
+                    if (!URLEncoder.encode(queryStringValue, StandardCharsets.UTF_8.name()).equals(queryStringValue)) {
+                        queryStringValue = URLEncoder.encode(queryStringValue, StandardCharsets.UTF_8.name());
+                    }
+                } catch (UnsupportedEncodingException e) {
+                    // TODO: Should we stop for the exception?
+                    lamdaContext.getLogger().log("Could not URLEncode: " + queryStringKey);
+                    e.printStackTrace();
+                }
+                params += separator + queryStringKey + "=" + queryStringValue;
+            }
+        }
+
+        return params;
+    }
+
+    /**
+     * Generic method to parse an HTTP header value and split it into a list of key/values for all its components.
+     * When the property in the header does not specify a key the key field in the output pair is null and only the value
+     * is populated. For example, The header <code>Accept: application/json; application/xml</code> will contain two
+     * key value pairs with key null and the value set to application/json and application/xml respectively.
+     *
+     * @param headerContent The string value for the HTTP header
+     * @return A list of SimpleMapEntry objects with all of the possible values for the header.
+     */
+    protected List<AbstractMap.SimpleEntry<String, String>> parseHeaderValue(String headerContent) {
+        List<AbstractMap.SimpleEntry<String, String>> values = new ArrayList<>();
+        if (headerContent != null) {
+            for (String kv : headerContent.split(HEADER_VALUE_SEPARATOR)) {
+                String[] kvSplit = kv.split(HEADER_KEY_VALUE_SEPARATOR);
+
+                if (kvSplit.length != 2) {
+                    values.add(new AbstractMap.SimpleEntry<>(null, kv.trim()));
+                } else {
+                    values.add(new AbstractMap.SimpleEntry<>(kvSplit[0].trim(), kvSplit[1].trim()));
+                }
+            }
+        }
+        return values;
+    }
+
+    //-------------------------------------------------------------
+    // Implementation - HttpServletRequest
+    //-------------------------------------------------------------
+
+    @Override
+    public String getRequestedSessionId() {
+        // TODO: Throw not implemented
+        return null;
+    }
+
+    @Override
+    public HttpSession getSession(boolean b) {
+        return null;
+    }
+
+
+    @Override
+    public HttpSession getSession() {
+        return null;
+    }
+
+
+    @Override
+    public String changeSessionId() {
+        return null;
+    }
+
+
+    @Override
+    public boolean isRequestedSessionIdValid() {
+        return false;
+    }
+
+
+    @Override
+    public boolean isRequestedSessionIdFromCookie() {
+        return false;
+    }
+
+
+    @Override
+    public boolean isRequestedSessionIdFromURL() {
+        return false;
+    }
+
+
+    @Override
+    public boolean isRequestedSessionIdFromUrl() {
+        return false;
+    }
+
+    @Override
+    public Object getAttribute(String s) {
+        return attributes.get(s);
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        return Collections.enumeration(attributes.keySet());
+    }
+
+    @Override
+    public void setAttribute(String s, Object o) {
+        attributes.put(s, o);
+    }
+
+
+    @Override
+    public void removeAttribute(String s) {
+        attributes.remove(s);
+    }
+
+    @Override
+    public String getServerName() {
+        return "lambda.amazonaws.com";
+    }
+
+
+    @Override
+    public int getServerPort() {
+        return 0;
+    }
+
+    @Override
+    public String getLocalName() {
+        return "lambda.amazonaws.com";
+    }
+
+
+    @Override
+    public String getLocalAddr() {
+        return null;
+    }
+
+
+    @Override
+    public int getLocalPort() {
+        return 0;
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        return false;
+    }
+
+
+    @Override
+    public boolean isAsyncSupported() {
+        return false;
+    }
+
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        return null;
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return AwsServletContext.getInstance(lamdaContext);
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        return dispatcherType;
+    }
+}

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsLambdaServletContainerHandler.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsLambdaServletContainerHandler.java
@@ -67,7 +67,7 @@ public abstract class AwsLambdaServletContainerHandler<RequestType, ResponseType
      * Sets the ServletContext in the handler and initialized a new <code>FilterChainManager</code>
      * @param context An initialized ServletContext
      */
-    protected void setServletContext(ServletContext context) {
+    protected void setServletContext(final ServletContext context) {
         servletContext = context;
         // We assume custom implementations of the RequestWriter for HttpServletRequest will reuse
         // the existing AwsServletContext object since it has no dependencies other than the Lambda context
@@ -114,7 +114,7 @@ public abstract class AwsLambdaServletContainerHandler<RequestType, ResponseType
      * </pre>
      * @param h A lambda expression that implements the <code>StartupHandler</code> functional interface
      */
-    public void setStartupHandler(StartupHandler h) {
+    public void setStartupHandler(final StartupHandler h) {
         startupHandler = h;
     }
 

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsLambdaServletContainerHandler.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsLambdaServletContainerHandler.java
@@ -35,8 +35,9 @@ public abstract class AwsLambdaServletContainerHandler<RequestType, ResponseType
         extends LambdaContainerHandler<RequestType, ResponseType, ContainerRequestType, ContainerResponseType> {
 
     //-------------------------------------------------------------
-    // Variables - Protected
+    // Variables - Private
     //-------------------------------------------------------------
+
 
     private FilterChainManager filterChainManager;
 
@@ -59,9 +60,20 @@ public abstract class AwsLambdaServletContainerHandler<RequestType, ResponseType
         super(requestReader, responseWriter, securityContextWriter, exceptionHandler);
     }
 
+
     //-------------------------------------------------------------
-    // Methods - Protected
+    // Methods - Getter/Setter
     //-------------------------------------------------------------
+
+    /**
+     * Returns the current ServletContext. If the framework implementation does not set the value for
+     * servlet context this method will return null.
+     * @return The initialized servlet context if the framework-specific implementation requires one, otherwise null
+     */
+    public ServletContext getServletContext() {
+        return servletContext;
+    }
+
 
     /**
      * Sets the ServletContext in the handler and initialized a new <code>FilterChainManager</code>
@@ -74,28 +86,6 @@ public abstract class AwsLambdaServletContainerHandler<RequestType, ResponseType
         filterChainManager = new AwsFilterChainManager((AwsServletContext)context);
     }
 
-    /**
-     * Applies the filter chain in the request lifecycle
-     * @param request The Request object. This must be an implementation of HttpServletRequest
-     * @param response The response object. This must be an implementation of HttpServletResponse
-     */
-    protected void doFilter(ContainerRequestType request, ContainerResponseType response) throws IOException, ServletException {
-        FilterChainHolder chain = filterChainManager.getFilterChain(request);
-        chain.doFilter(request, response);
-    }
-
-    //-------------------------------------------------------------
-    // Methods - Public
-    //-------------------------------------------------------------
-
-    /**
-     * Returns the current ServletContext. If the framework implementation does not set the value for
-     * servlet context this method will return null.
-     * @return The initialized servlet context if the framework-specific implementation requires one, otherwise null
-     */
-    public ServletContext getServletContext() {
-        return servletContext;
-    }
 
     /**
      * You can use the <code>setStartupHandler</code> to intercept the ServletContext as the Spring application is
@@ -118,7 +108,32 @@ public abstract class AwsLambdaServletContainerHandler<RequestType, ResponseType
         startupHandler = h;
     }
 
+
+    //-------------------------------------------------------------
+    // Methods - Protected
+    //-------------------------------------------------------------
+
+    /**
+     * Applies the filter chain in the request lifecycle
+     * @param request The Request object. This must be an implementation of HttpServletRequest
+     * @param response The response object. This must be an implementation of HttpServletResponse
+     */
+    protected void doFilter(ContainerRequestType request, ContainerResponseType response) throws IOException, ServletException {
+        FilterChainHolder chain = filterChainManager.getFilterChain(request);
+        chain.doFilter(request, response);
+    }
+
+
+    //-------------------------------------------------------------
+    // Inner Class -
+    //-------------------------------------------------------------
+
     public interface StartupHandler {
+
+        //-------------------------------------------------------------
+        // Methods - Public
+        //-------------------------------------------------------------
+
         void onStartup(ServletContext context);
     }
 }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsLambdaServletContainerHandler.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsLambdaServletContainerHandler.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.serverless.proxy.internal.servlet;
+
+import com.amazonaws.serverless.proxy.internal.*;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Abstract extension of the code <code>LambdaContainerHandler</code> object that adds protected variables for the
+ * <code>ServletContext</code> and <code>FilterChainManager</code>. This object should be extended by the framework-specific
+ * implementations that want to support the servlet 3.1 specs.
+ * @param <RequestType>
+ * @param <ResponseType>
+ * @param <ContainerRequestType>
+ * @param <ContainerResponseType>
+ */
+public abstract class AwsLambdaServletContainerHandler<RequestType, ResponseType,
+        ContainerRequestType extends HttpServletRequest,
+        ContainerResponseType extends HttpServletResponse>
+        extends LambdaContainerHandler<RequestType, ResponseType, ContainerRequestType, ContainerResponseType> {
+
+    //-------------------------------------------------------------
+    // Variables - Protected
+    //-------------------------------------------------------------
+
+    private FilterChainManager filterChainManager;
+
+    //-------------------------------------------------------------
+    // Variables - Protected
+    //-------------------------------------------------------------
+
+    protected ServletContext servletContext;
+    protected StartupHandler startupHandler;
+
+
+    //-------------------------------------------------------------
+    // Constructors
+    //-------------------------------------------------------------
+
+    protected AwsLambdaServletContainerHandler(RequestReader<RequestType, ContainerRequestType> requestReader,
+                                     ResponseWriter<ContainerResponseType, ResponseType> responseWriter,
+                                     SecurityContextWriter<RequestType> securityContextWriter,
+                                     ExceptionHandler<ResponseType> exceptionHandler) {
+        super(requestReader, responseWriter, securityContextWriter, exceptionHandler);
+    }
+
+    //-------------------------------------------------------------
+    // Methods - Protected
+    //-------------------------------------------------------------
+
+    /**
+     * Sets the ServletContext in the handler and initialized a new <code>FilterChainManager</code>
+     * @param context An initialized ServletContext
+     */
+    protected void setServletContext(ServletContext context) {
+        servletContext = context;
+        // We assume custom implementations of the RequestWriter for HttpServletRequest will reuse
+        // the existing AwsServletContext object since it has no dependencies other than the Lambda context
+        filterChainManager = new AwsFilterChainManager((AwsServletContext)context);
+    }
+
+    /**
+     * Applies the filter chain in the request lifecycle
+     * @param request The Request object. This must be an implementation of HttpServletRequest
+     * @param response The response object. This must be an implementation of HttpServletResponse
+     */
+    protected void doFilter(ContainerRequestType request, ContainerResponseType response) throws IOException, ServletException {
+        FilterChainHolder chain = filterChainManager.getFilterChain(request);
+        chain.doFilter(request, response);
+    }
+
+    //-------------------------------------------------------------
+    // Methods - Public
+    //-------------------------------------------------------------
+
+    /**
+     * Returns the current ServletContext. If the framework implementation does not set the value for
+     * servlet context this method will return null.
+     * @return The initialized servlet context if the framework-specific implementation requires one, otherwise null
+     */
+    public ServletContext getServletContext() {
+        return servletContext;
+    }
+
+    /**
+     * You can use the <code>setStartupHandler</code> to intercept the ServletContext as the Spring application is
+     * initialized and inject custom values. The StartupHandler is called after the <code>onStartup</code> method
+     * of the <code>LambdaSpringApplicationinitializer</code> implementation. For example, you can use this method to
+     * add custom filters to the servlet context:
+     *
+     * <pre>
+     * {@code
+     *      handler = SpringLambdaContainerHandler.getAwsProxyHandler(EchoSpringAppConfig.class);
+     *      handler.setStartupHandler(c -> {
+     *      // the "c" parameter to this function is the initialized servlet context
+     *      c.addFilter("CustomHeaderFilter", CustomHeaderFilter.class);
+     *      });
+     * }
+     * </pre>
+     * @param h A lambda expression that implements the <code>StartupHandler</code> functional interface
+     */
+    public void setStartupHandler(StartupHandler h) {
+        startupHandler = h;
+    }
+
+    public interface StartupHandler {
+        void onStartup(ServletContext context);
+    }
+}

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsLambdaServletContainerHandler.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsLambdaServletContainerHandler.java
@@ -42,7 +42,6 @@ public abstract class AwsLambdaServletContainerHandler<RequestType, ResponseType
     // Variables - Private
     //-------------------------------------------------------------
 
-
     private FilterChainManager filterChainManager;
 
     //-------------------------------------------------------------
@@ -92,7 +91,7 @@ public abstract class AwsLambdaServletContainerHandler<RequestType, ResponseType
 
 
     /**
-     * You can use the <code>setStartupHandler</code> to intercept the ServletContext as the Spring application is
+     * You can use the <code>onStartup</code> to intercept the ServletContext as the Spring application is
      * initialized and inject custom values. The StartupHandler is called after the <code>onStartup</code> method
      * of the <code>LambdaSpringApplicationinitializer</code> implementation. For example, you can use this method to
      * add custom filters to the servlet context:
@@ -100,7 +99,7 @@ public abstract class AwsLambdaServletContainerHandler<RequestType, ResponseType
      * <pre>
      * {@code
      *      handler = SpringLambdaContainerHandler.getAwsProxyHandler(EchoSpringAppConfig.class);
-     *      handler.setStartupHandler(c -> {
+     *      handler.onStartup(c -> {
      *      // the "c" parameter to this function is the initialized servlet context
      *      c.addFilter("CustomHeaderFilter", CustomHeaderFilter.class);
      *      });
@@ -108,7 +107,7 @@ public abstract class AwsLambdaServletContainerHandler<RequestType, ResponseType
      * </pre>
      * @param h A lambda expression that implements the <code>StartupHandler</code> functional interface
      */
-    public void setStartupHandler(final StartupHandler h) {
+    public void onStartup(final StartupHandler h) {
         startupHandler = h;
     }
 

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsLambdaServletContainerHandler.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsLambdaServletContainerHandler.java
@@ -12,7 +12,11 @@
  */
 package com.amazonaws.serverless.proxy.internal.servlet;
 
-import com.amazonaws.serverless.proxy.internal.*;
+import com.amazonaws.serverless.proxy.internal.ExceptionHandler;
+import com.amazonaws.serverless.proxy.internal.LambdaContainerHandler;
+import com.amazonaws.serverless.proxy.internal.RequestReader;
+import com.amazonaws.serverless.proxy.internal.ResponseWriter;
+import com.amazonaws.serverless.proxy.internal.SecurityContextWriter;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -30,8 +34,8 @@ import java.io.IOException;
  * @param <ContainerResponseType>
  */
 public abstract class AwsLambdaServletContainerHandler<RequestType, ResponseType,
-        ContainerRequestType extends HttpServletRequest,
-        ContainerResponseType extends HttpServletResponse>
+                                                        ContainerRequestType extends HttpServletRequest,
+                                                        ContainerResponseType extends HttpServletResponse>
         extends LambdaContainerHandler<RequestType, ResponseType, ContainerRequestType, ContainerResponseType> {
 
     //-------------------------------------------------------------

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
@@ -44,7 +44,20 @@ import java.net.URLDecoder;
 import java.security.Principal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+
 
 /**
  * Implementation of the <code>HttpServletRequest</code> interface that supports <code>AwsProxyRequest</code> object.
@@ -93,7 +106,7 @@ public class AwsProxyHttpServletRequest extends AwsHttpServletRequest {
         if (cookieHeader == null) {
             return new Cookie[0];
         }
-        return this.parseCookies(cookieHeader);
+        return this.parseCookieHeaderValue(cookieHeader);
     }
 
 
@@ -233,21 +246,20 @@ public class AwsProxyHttpServletRequest extends AwsHttpServletRequest {
     @Override
     public boolean authenticate(HttpServletResponse httpServletResponse)
             throws IOException, ServletException {
-        // TODO: Throw not implemented
-        return false;
+        throw new UnsupportedOperationException();
     }
 
 
     @Override
     public void login(String s, String s1)
             throws ServletException {
-        // TODO: Throw not implemented
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void logout()
             throws ServletException {
-        // TODO: Throw not implemented
+        throw new UnsupportedOperationException();
     }
 
 
@@ -531,7 +543,7 @@ public class AwsProxyHttpServletRequest extends AwsHttpServletRequest {
 
     @Override
     public Locale getLocale() {
-        List<AbstractMap.SimpleEntry<String, String>> values = this.parseHeaderValue(
+        List<Map.Entry<String, String>> values = this.parseHeaderValue(
                 getHeaderCaseInsensitive(HttpHeaders.ACCEPT_LANGUAGE)
         );
         if (values.size() == 0) {
@@ -543,14 +555,14 @@ public class AwsProxyHttpServletRequest extends AwsHttpServletRequest {
 
     @Override
     public Enumeration<Locale> getLocales() {
-        List<AbstractMap.SimpleEntry<String, String>> values = this.parseHeaderValue(
+        List<Map.Entry<String, String>> values = this.parseHeaderValue(
                 getHeaderCaseInsensitive(HttpHeaders.ACCEPT_LANGUAGE)
         );
         List<Locale> locales = new ArrayList<>();
         if (values.size() == 0) {
             locales.add(Locale.getDefault());
         } else {
-            for (AbstractMap.SimpleEntry<String, String> locale : values) {
+            for (Map.Entry<String, String> locale : values) {
                 locales.add(new Locale(locale.getValue()));
             }
         }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContext.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContext.java
@@ -46,9 +46,8 @@ public class AwsServletContext
         implements ServletContext {
 
     //-------------------------------------------------------------
-    // Constants
-    //-------------------------------------------------------------
-
+    // Constants - Public
+    // -------------------------------------------------------------
     public static final int SERVLET_API_MAJOR_VERSION = 3;
     public static final int SERVLET_API_MINOR_VERSION = 1;
 
@@ -56,18 +55,16 @@ public class AwsServletContext
     //-------------------------------------------------------------
     // Variables - Private
     //-------------------------------------------------------------
-
+    private static AwsServletContext instance;
     private Context lambdaContext;
     private Map<String, Object> attributes;
     private Map<String, String> initParameters;
-    private Map<String, FilterHolder> filters;
 
 
     //-------------------------------------------------------------
     // Variables - Private - Static
     //-------------------------------------------------------------
-
-    private static AwsServletContext instance;
+    private Map<String, FilterHolder> filters;
 
 
     //-------------------------------------------------------------
@@ -86,6 +83,20 @@ public class AwsServletContext
     //-------------------------------------------------------------
     // Implementation - ServletContext
     //-------------------------------------------------------------
+
+
+    public static ServletContext getInstance(Context lambdaContext) {
+        if (instance == null) {
+            instance = new AwsServletContext(lambdaContext);
+        }
+
+        return instance;
+    }
+
+
+    public static void clearServletContextCache() {
+        instance = null;
+    }
 
 
     @Override
@@ -354,10 +365,8 @@ public class AwsServletContext
             return null;
         }
 
-        FilterHolder newFilter = new FilterHolder(filter, this);
-        if (!"".equals(name.trim())) {
-            newFilter.setFilterName(name);
-        }
+        FilterHolder newFilter = new FilterHolder(name, filter, this);
+
         filters.put(newFilter.getFilterName(), newFilter);
         return newFilter.getRegistration();
     }
@@ -397,6 +406,7 @@ public class AwsServletContext
         return filters.get(s).getRegistration();
     }
 
+
     @Override
     public Map<String, ? extends FilterRegistration> getFilterRegistrations() {
         Map<String, FilterRegistration> registrations = new LinkedHashMap<>();
@@ -405,6 +415,7 @@ public class AwsServletContext
         }
         return registrations;
     }
+
 
     Map<String, FilterHolder> getFilterHolders() {
         return filters;
@@ -421,6 +432,7 @@ public class AwsServletContext
     public void setSessionTrackingModes(Set<SessionTrackingMode> set) {
 
     }
+
 
     @Override
     public Set<SessionTrackingMode> getDefaultSessionTrackingModes() {
@@ -439,15 +451,18 @@ public class AwsServletContext
 
     }
 
+
     @Override
     public <T extends EventListener> void addListener(T t) {
 
     }
 
+
     @Override
     public void addListener(Class<? extends EventListener> aClass) {
 
     }
+
 
     @Override
     public <T extends EventListener> T createListener(Class<T> aClass) throws ServletException {
@@ -468,25 +483,15 @@ public class AwsServletContext
         return ClassLoader.getSystemClassLoader();
     }
 
+
     @Override
     public void declareRoles(String... strings) {
 
     }
 
+
     @Override
     public String getVirtualServerName() {
         return null;
-    }
-
-    public static ServletContext getInstance(Context lambdaContext) {
-        if (instance == null) {
-            instance = new AwsServletContext(lambdaContext);
-        }
-
-        return instance;
-    }
-
-    public static void clearServletContextCache() {
-        instance = null;
     }
 }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContext.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContext.java
@@ -354,8 +354,11 @@ public class AwsServletContext
             return null;
         }
 
-        FilterHolder newFilter = new FilterHolder(name, filter, this);
-        filters.put(name, newFilter);
+        FilterHolder newFilter = new FilterHolder(filter, this);
+        if (!"".equals(name.trim())) {
+            newFilter.setFilterName(name);
+        }
+        filters.put(newFilter.getFilterName(), newFilter);
         return newFilter.getRegistration();
     }
 

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainHolder.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainHolder.java
@@ -97,7 +97,8 @@ public class FilterChainHolder implements FilterChain {
         if (filters == null || filters.size() == 0 || currentFilter > filters.size() - 1) {
             return;
         }
-        // TODO: We do check for async filters here
+        // TODO: We do not check for async filters here
+
         FilterHolder holder = filters.get(currentFilter);
 
         if (!holder.isFilterInitialized()) {

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainHolder.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainHolder.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.serverless.proxy.internal.servlet;
+
+import javax.servlet.*;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Implementation of the <code>FilterChain</code> interface. FilterChainHolder objects should be accessed through the
+ * <code>FilterChainManager</code>. Once a filter chain is loaded, use the <code>doFilter</code> emthod to run the chain
+ * during a request lifecycle
+ */
+public class FilterChainHolder implements FilterChain {
+    //-------------------------------------------------------------
+    // Variables - Private
+    //-------------------------------------------------------------
+
+    private List<FilterHolder> filters;
+    private int currentFilter;
+
+    //-------------------------------------------------------------
+    // Constructors
+    //-------------------------------------------------------------
+
+    /**
+     * Creates a new instance of a filter chain holder
+     * @param allFilters A populated list of <code>FilterHolder</code> objects
+     */
+    public FilterChainHolder(List<FilterHolder> allFilters) {
+        filters = allFilters;
+        currentFilter = -1;
+    }
+
+    /**
+     * Creates a new empty <code>FilterChainHolder</code>
+     */
+    public FilterChainHolder() {
+        this(new ArrayList<>());
+    }
+
+    //-------------------------------------------------------------
+    // Methods - Public
+    //-------------------------------------------------------------
+
+    /**
+     * Add a filter to the chain.
+     * @param newFilter The filter to be added at the end of the chain
+     */
+    public void addFilter(FilterHolder newFilter) {
+        filters.add(newFilter);
+    }
+
+    //-------------------------------------------------------------
+    // Implementation - FilterChain
+    //-------------------------------------------------------------
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse) throws IOException, ServletException {
+        currentFilter++;
+        if (filters == null || filters.size() == 0 || currentFilter > filters.size() - 1) {
+            return;
+        }
+        // TODO: We do check for async filters here
+        FilterHolder holder = filters.get(currentFilter);
+
+        if (!holder.isFilterInitialized()) {
+            holder.init();
+        }
+        holder.getFilter().doFilter(servletRequest, servletResponse, this);
+    }
+}

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainHolder.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainHolder.java
@@ -12,7 +12,11 @@
  */
 package com.amazonaws.serverless.proxy.internal.servlet;
 
-import javax.servlet.*;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainHolder.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainHolder.java
@@ -23,6 +23,7 @@ import java.util.List;
  * during a request lifecycle
  */
 public class FilterChainHolder implements FilterChain {
+
     //-------------------------------------------------------------
     // Variables - Private
     //-------------------------------------------------------------
@@ -30,9 +31,18 @@ public class FilterChainHolder implements FilterChain {
     private List<FilterHolder> filters;
     private int currentFilter;
 
+
     //-------------------------------------------------------------
     // Constructors
     //-------------------------------------------------------------
+
+    /**
+     * Creates a new empty <code>FilterChainHolder</code>
+     */
+    public FilterChainHolder() {
+        this(new ArrayList<>());
+    }
+
 
     /**
      * Creates a new instance of a filter chain holder
@@ -43,49 +53,6 @@ public class FilterChainHolder implements FilterChain {
         currentFilter = -1;
     }
 
-    /**
-     * Creates a new empty <code>FilterChainHolder</code>
-     */
-    public FilterChainHolder() {
-        this(new ArrayList<>());
-    }
-
-    //-------------------------------------------------------------
-    // Methods - Public
-    //-------------------------------------------------------------
-
-    /**
-     * Add a filter to the chain.
-     * @param newFilter The filter to be added at the end of the chain
-     */
-    public void addFilter(FilterHolder newFilter) {
-        filters.add(newFilter);
-    }
-
-    /**
-     * Returns the number of filters loaded in the chain holder
-     * @return The number of filters in the chain holder. If the filter chain is null then this will return 0
-     */
-    public int filterCount() {
-        if (filters == null) {
-            return 0;
-        } else {
-            return filters.size();
-        }
-    }
-
-    /**
-     * Get the <code>FilterHolder</code> object from the chain at the given index.
-     * @param idx The index in the chain. Use the <code>filterCount</code> method to get the filter count
-     * @return A populated FilterHolder object
-     */
-    public FilterHolder getFilter(int idx) {
-        if (filters == null) {
-            return null;
-        } else {
-            return filters.get(idx);
-        }
-    }
 
     //-------------------------------------------------------------
     // Implementation - FilterChain
@@ -105,5 +72,45 @@ public class FilterChainHolder implements FilterChain {
             holder.init();
         }
         holder.getFilter().doFilter(servletRequest, servletResponse, this);
+    }
+
+
+    //-------------------------------------------------------------
+    // Methods - Public
+    //-------------------------------------------------------------
+
+    /**
+     * Add a filter to the chain.
+     * @param newFilter The filter to be added at the end of the chain
+     */
+    public void addFilter(FilterHolder newFilter) {
+        filters.add(newFilter);
+    }
+
+
+    /**
+     * Returns the number of filters loaded in the chain holder
+     * @return The number of filters in the chain holder. If the filter chain is null then this will return 0
+     */
+    public int filterCount() {
+        if (filters == null) {
+            return 0;
+        } else {
+            return filters.size();
+        }
+    }
+
+
+    /**
+     * Get the <code>FilterHolder</code> object from the chain at the given index.
+     * @param idx The index in the chain. Use the <code>filterCount</code> method to get the filter count
+     * @return A populated FilterHolder object
+     */
+    public FilterHolder getFilter(int idx) {
+        if (filters == null) {
+            return null;
+        } else {
+            return filters.get(idx);
+        }
     }
 }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainHolder.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainHolder.java
@@ -62,6 +62,31 @@ public class FilterChainHolder implements FilterChain {
         filters.add(newFilter);
     }
 
+    /**
+     * Returns the number of filters loaded in the chain holder
+     * @return The number of filters in the chain holder. If the filter chain is null then this will return 0
+     */
+    public int filterCount() {
+        if (filters == null) {
+            return 0;
+        } else {
+            return filters.size();
+        }
+    }
+
+    /**
+     * Get the <code>FilterHolder</code> object from the chain at the given index.
+     * @param idx The index in the chain. Use the <code>filterCount</code> method to get the filter count
+     * @return A populated FilterHolder object
+     */
+    public FilterHolder getFilter(int idx) {
+        if (filters == null) {
+            return null;
+        } else {
+            return filters.get(idx);
+        }
+    }
+
     //-------------------------------------------------------------
     // Implementation - FilterChain
     //-------------------------------------------------------------

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainManager.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainManager.java
@@ -29,6 +29,13 @@ import java.util.Map;
 public abstract class FilterChainManager<ServletContextType> {
 
     //-------------------------------------------------------------
+    // Variables - Protected
+    //-------------------------------------------------------------
+
+    protected static final String PATH_PART_SEPARATOR = "/";
+
+
+    //-------------------------------------------------------------
     // Variables - Private
     //-------------------------------------------------------------
 
@@ -36,13 +43,8 @@ public abstract class FilterChainManager<ServletContextType> {
     // event at a time per container
     private Map<TargetCacheKey, FilterChainHolder> filterCache = Collections.synchronizedMap(new HashMap<TargetCacheKey, FilterChainHolder>());
     private int filtersSize = -1;
-
-    //-------------------------------------------------------------
-    // Variables - Protected
-    //-------------------------------------------------------------
-
-    protected static final String PATH_PART_SEPARATOR = "/";
     protected ServletContextType servletContext;
+
 
     //-------------------------------------------------------------
     // Constructors
@@ -51,6 +53,7 @@ public abstract class FilterChainManager<ServletContextType> {
     protected FilterChainManager(ServletContextType context) {
         servletContext = context;
     }
+
 
     //-------------------------------------------------------------
     // Methods - Abstract
@@ -62,6 +65,7 @@ public abstract class FilterChainManager<ServletContextType> {
      * @return A Map of filter holders with the filter name as key and the filter holder object as value
      */
     protected abstract Map<String, FilterHolder> getFilterHolders();
+
 
     //-------------------------------------------------------------
     // Methods - Public
@@ -119,6 +123,7 @@ public abstract class FilterChainManager<ServletContextType> {
         return chainHolder;
     }
 
+
     //-------------------------------------------------------------
     // Methods - Protected
     //-------------------------------------------------------------
@@ -137,6 +142,7 @@ public abstract class FilterChainManager<ServletContextType> {
 
         return filterCache.get(key);
     }
+
 
     /**
      * Adds a filter chain to the local cache. The key for the filter chain in the cache is generated with the dispatcher
@@ -159,6 +165,7 @@ public abstract class FilterChainManager<ServletContextType> {
 
         filterCache.put(key, holder);
     }
+
 
     /**
      * Checks if a mapping path matches the target path of the request. The mapping path can include wildcards. For example,
@@ -209,29 +216,28 @@ public abstract class FilterChainManager<ServletContextType> {
         return true;
     }
 
+
+    //-------------------------------------------------------------
+    // Inner Class -
+    //-------------------------------------------------------------
+
     /**
      * Object used as a key for the filter chain cache. It contains a target path and dispatcher type property. It overrides
      * the default <code>hashCode</code> and <code>equals</code> methods to return a consistent hash for comparison.
      */
     protected static class TargetCacheKey {
+
+    //-------------------------------------------------------------
+    // Variables - Private
+    //-------------------------------------------------------------
+
         private String targetPath;
         private DispatcherType dispatcherType;
 
-        public String getTargetPath() {
-            return targetPath;
-        }
 
-        public void setTargetPath(String targetPath) {
-            this.targetPath = targetPath;
-        }
-
-        public DispatcherType getDispatcherType() {
-            return dispatcherType;
-        }
-
-        public void setDispatcherType(DispatcherType dispatcherType) {
-            this.dispatcherType = dispatcherType;
-        }
+    //-------------------------------------------------------------
+    // Methods - Public
+    //-------------------------------------------------------------
 
         /**
          * The hash code for a cache key is calculated using the target path and dispatcher type. First, the target path
@@ -263,6 +269,7 @@ public abstract class FilterChainManager<ServletContextType> {
             return hashString.hashCode();
         }
 
+
         @Override
         public boolean equals(Object key) {
             if (!key.getClass().isAssignableFrom(TargetCacheKey.class)) {
@@ -270,6 +277,30 @@ public abstract class FilterChainManager<ServletContextType> {
             } else {
                 return hashCode() == key.hashCode();
             }
+        }
+
+
+    //-------------------------------------------------------------
+    // Methods - Getter/Setter
+    //-------------------------------------------------------------
+
+        public String getTargetPath() {
+            return targetPath;
+        }
+
+
+        public void setTargetPath(String targetPath) {
+            this.targetPath = targetPath;
+        }
+
+
+        public DispatcherType getDispatcherType() {
+            return dispatcherType;
+        }
+
+
+        public void setDispatcherType(DispatcherType dispatcherType) {
+            this.dispatcherType = dispatcherType;
         }
     }
 }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainManager.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainManager.java
@@ -76,7 +76,7 @@ public abstract class FilterChainManager<ServletContextType> {
      * @param request The incoming servlet request
      * @return A <code>FilterChainHolder</code> object that can be used to apply the filters to the request
      */
-    public FilterChainHolder getFilterChain(HttpServletRequest request) {
+    public FilterChainHolder getFilterChain(final HttpServletRequest request) {
         String targetPath = request.getServletPath();
         DispatcherType type = request.getDispatcherType();
 
@@ -130,7 +130,7 @@ public abstract class FilterChainManager<ServletContextType> {
      * @param targetPath The request path - this is extracted with the <code>getPath</code> method of the request object
      * @return A populated FilterChainHolder
      */
-    protected FilterChainHolder getFilterChainCache(DispatcherType type, String targetPath) {
+    protected FilterChainHolder getFilterChainCache(final DispatcherType type, final String targetPath) {
         TargetCacheKey key = new TargetCacheKey();
         key.setDispatcherType(type);
         key.setTargetPath(targetPath);
@@ -147,7 +147,7 @@ public abstract class FilterChainManager<ServletContextType> {
      * @param targetPath The target path in the API
      * @param holder The FilterChainHolder object to save in the cache
      */
-    protected void putFilterChainCache(DispatcherType type, String targetPath, FilterChainHolder holder) {
+    protected void putFilterChainCache(final DispatcherType type, final String targetPath, final FilterChainHolder holder) {
         TargetCacheKey key = new TargetCacheKey();
         key.setDispatcherType(type);
         key.setTargetPath(targetPath);
@@ -167,7 +167,7 @@ public abstract class FilterChainManager<ServletContextType> {
      * @param mapping The mapping path stored in the filter registration
      * @return true if the given mapping path can apply to the target, false otherwise.
      */
-    protected boolean pathMatches(String target, String mapping) {
+    protected boolean pathMatches(final String target, final String mapping) {
         // easiest case, they are exactly the same
         if (target.toLowerCase().equals(mapping.toLowerCase())) {
             return true;

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainManager.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainManager.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.serverless.proxy.internal.servlet;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This object in in charge of matching a servlet request to a set of filter, creating the filter chain for a request,
+ * and cache filter chains that were already loaded for re-use. This object should be used by the framework-specific
+ * implementations that use the <code>HttpServletRequest</code> and <code>HttpServletResponse</code> objects.
+ *
+ * For example, the Spring implementation creates the ServletContext when the application is initialized the first time
+ * and creates a FitlerChainManager to execute its filters for each request.
+ */
+public abstract class FilterChainManager<ServletContextType> {
+
+    //-------------------------------------------------------------
+    // Variables - Private
+    //-------------------------------------------------------------
+
+    // we use the synchronizedMap because we do not expect high concurrency on this object. Lambda only allows one
+    // event at a time per container
+    private Map<TargetCacheKey, FilterChainHolder> filterCache = Collections.synchronizedMap(new HashMap<TargetCacheKey, FilterChainHolder>());
+
+    //-------------------------------------------------------------
+    // Variables - Protected
+    //-------------------------------------------------------------
+
+    protected static final String PATH_PART_SEPARATOR = "/";
+    protected ServletContextType servletContext;
+
+    //-------------------------------------------------------------
+    // Constructors
+    //-------------------------------------------------------------
+
+    protected FilterChainManager(ServletContextType context) {
+        servletContext = context;
+    }
+
+    //-------------------------------------------------------------
+    // Methods - Abstract
+    //-------------------------------------------------------------
+
+    /**
+     * This method is used by the <code>getFilterChain</code> method to extract a Map of filter holders from the current
+     * context. This method is implemented in the <code>AwsFilterChainManager</code> class.
+     * @return A Map of filter holders with the filter name as key and the filter holder object as value
+     */
+    protected abstract Map<String, FilterHolder> getFilterHolders();
+
+    //-------------------------------------------------------------
+    // Methods - Public
+    //-------------------------------------------------------------
+
+    /**
+     * Returns the filter chain that applies to the given request. The method matches requests to filters using the
+     * <code>DispatcherType</code> value (set to REQUEST by default in the AwsProxyHttpServletRequest) and the target
+     * path returned by the <code>getPath</code> method of the request.
+     *
+     * This method currently does not filter on servlet name because the library assumes we are using a single servlet.
+     * @param request The incoming servlet request
+     * @return A <code>FilterChainHolder</code> object that can be used to apply the filters to the request
+     */
+    public FilterChainHolder getFilterChain(HttpServletRequest request) {
+        String targetPath = request.getServletPath();
+        DispatcherType type = request.getDispatcherType();
+
+        if (getFilterChainCache(type, targetPath) != null) {
+            return getFilterChainCache(type, targetPath);
+        }
+
+        FilterChainHolder chainHolder = new FilterChainHolder();
+
+        Map<String, FilterHolder> registrations = getFilterHolders();
+        if (registrations == null || registrations.size() == 0) {
+            return chainHolder;
+        }
+        for (String name : registrations.keySet()) {
+            FilterHolder holder = registrations.get(name);
+            // we only check the dispatcher type if it's not empty. Otherwise we assume it's a REQUEST as per section 6.2.5
+            // of servlet specs
+            if (holder.getRegistration().getDispatcherTypes().size() > 0 && !holder.getRegistration().getDispatcherTypes().contains(type)) {
+                continue;
+            }
+            for (String path : holder.getRegistration().getUrlPatternMappings()) {
+                if (pathMatches(targetPath, path)) {
+                    chainHolder.addFilter(holder);
+                }
+            }
+
+            // TODO: We do not allow programmatic registration of servlets so we never check for servlet name
+            // we assume we only ever have one servlet.
+        }
+
+        putFilterChainCache(type, targetPath, chainHolder);
+        return chainHolder;
+    }
+
+    //-------------------------------------------------------------
+    // Methods - Protected
+    //-------------------------------------------------------------
+
+    /**
+     * Retrieves a filter chain from the cache. The cache is lazily loaded as filter chains are requested. If the chain
+     * is not available in the cache, the method returns null.
+     * @param type The dispatcher type for the incoming request
+     * @param targetPath The request path - this is extracted with the <code>getPath</code> method of the request object
+     * @return A populated FilterChainHolder
+     */
+    protected FilterChainHolder getFilterChainCache(DispatcherType type, String targetPath) {
+        TargetCacheKey key = new TargetCacheKey();
+        key.setDispatcherType(type);
+        key.setTargetPath(targetPath);
+
+        return filterCache.get(key);
+    }
+
+    /**
+     * Adds a filter chain to the local cache. The key for the filter chain in the cache is generated with the dispatcher
+     * type and the path from the request. If we cannot compute the key for a filter chain, because either the path or
+     * dispatcher are null, this method returns without saving the chain in the cache. It's up to the <code>getFilterChain</code>
+     * method to retry this.
+     * @param type DispatcherType from the incoming request
+     * @param targetPath The target path in the API
+     * @param holder The FilterChainHolder object to save in the cache
+     */
+    protected void putFilterChainCache(DispatcherType type, String targetPath, FilterChainHolder holder) {
+        TargetCacheKey key = new TargetCacheKey();
+        key.setDispatcherType(type);
+        key.setTargetPath(targetPath);
+
+        // we couldn't compute the hash code because either the target path or dispatcher type were null
+        if (key.hashCode() == -1) {
+            return;
+        }
+
+        filterCache.put(key, holder);
+    }
+
+    /**
+     * Checks if a mapping path matches the target path of the request. The mapping path can include wildcards. For example,
+     * the filter configured for /echo/* will match for request coming to all sub-resources of /echo. If not path
+     * @param target The target path from the incoming request
+     * @param mapping The mapping path stored in the filter registration
+     * @return true if the given mapping path can apply to the target, false otherwise.
+     */
+    protected boolean pathMatches(String target, String mapping) {
+        // easiest case, they are exactly the same
+        if (target.toLowerCase().equals(mapping.toLowerCase())) {
+            return true;
+        }
+
+        String finalTarget = target;
+        String finalMapping = mapping;
+        // strip first slash
+        if (target.startsWith("/")) {
+            finalTarget = target.replaceFirst("/", "");
+        }
+        if (mapping.startsWith("/")) {
+            finalMapping = mapping.replaceFirst("/", "");
+        }
+
+        String[] targetParts = finalTarget.split(PATH_PART_SEPARATOR);
+        String[] mappingParts = finalMapping.split(PATH_PART_SEPARATOR);
+
+        // another simple case, the filter applies to everything
+        if (mappingParts.length == 1 && mappingParts[0].equals("*")) {
+            return true;
+        }
+
+        for (int i = 0; i < targetParts.length; i++) {
+            if (mappingParts.length < i + 1) {
+                // if we haven't matched anything yet we never will
+                return false;
+            }
+            // the exact work doesn't match the and holder is not a wildcard
+            if (!targetParts[i].equals(mappingParts[i]) && !mappingParts[i].equals("*")) {
+                return false;
+            } else {
+                // stop the loop, we have found a wildcard and all path parts prior to this matched.
+                break;
+            }
+
+        }
+
+        return true;
+    }
+
+    /**
+     * Object used as a key for the filter chain cache. It contains a target path and dispatcher type property. It overrides
+     * the default <code>hashCode</code> and <code>equals</code> methods to return a consistent hash for comparison.
+     */
+    private class TargetCacheKey {
+        private String targetPath;
+        private DispatcherType dispatcherType;
+
+        public String getTargetPath() {
+            return targetPath;
+        }
+
+        public void setTargetPath(String targetPath) {
+            this.targetPath = targetPath;
+        }
+
+        public DispatcherType getDispatcherType() {
+            return dispatcherType;
+        }
+
+        public void setDispatcherType(DispatcherType dispatcherType) {
+            this.dispatcherType = dispatcherType;
+        }
+
+        @Override
+        public int hashCode() {
+            if (targetPath == null || dispatcherType == null) {
+                return -1;
+            }
+            return (targetPath + ":" + dispatcherType.name()).hashCode();
+        }
+
+        @Override
+        public boolean equals(Object key) {
+            if (!key.getClass().isAssignableFrom(TargetCacheKey.class)) {
+                return false;
+            } else {
+                return hashCode() == key.hashCode();
+            }
+        }
+    }
+}

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainManager.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainManager.java
@@ -12,7 +12,7 @@
  */
 package com.amazonaws.serverless.proxy.internal.servlet;
 
-import javax.servlet.*;
+import javax.servlet.DispatcherType;
 import javax.servlet.http.HttpServletRequest;
 import java.util.Collections;
 import java.util.HashMap;
@@ -84,9 +84,6 @@ public abstract class FilterChainManager<ServletContextType> {
         String targetPath = request.getServletPath();
         DispatcherType type = request.getDispatcherType();
 
-        if (filtersSize == -1) {
-            getFilterHolders().size();
-        }
         // only return the cached result if the filter list hasn't changed in the meanwhile
         if (getFilterHolders().size() == filtersSize && getFilterChainCache(type, targetPath) != null) {
             return getFilterChainCache(type, targetPath);
@@ -252,19 +249,25 @@ public abstract class FilterChainManager<ServletContextType> {
          */
         @Override
         public int hashCode() {
-            if (targetPath == null || dispatcherType == null) {
-                return -1;
+            String hashPath = targetPath;
+            if (targetPath == null) {
+                hashPath = "/";
+            }
+
+            String hashDispatcher = "";
+            if (dispatcherType != null) {
+                hashDispatcher = dispatcherType.name();
             }
 
             // clean up path
-            String hashString = targetPath.trim();
+            String hashString = hashPath.trim();
             if (hashString.endsWith(PATH_PART_SEPARATOR)) {
                 hashString = hashString.substring(0, hashString.length() - 1);
             }
             if (!hashString.startsWith(PATH_PART_SEPARATOR)) {
                 hashString = PATH_PART_SEPARATOR + hashString;
             }
-            hashString += ":" + dispatcherType.name();
+            hashString += ":" + hashDispatcher;
 
             return hashString.hashCode();
         }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterHolder.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterHolder.java
@@ -28,9 +28,9 @@ public class FilterHolder {
     // Variables - Private
     //-------------------------------------------------------------
 
-    private  Filter filter;
-    private  FilterConfig filterConfig;
-    private  Registration registration;
+    private Filter filter;
+    private FilterConfig filterConfig;
+    private Registration registration;
     private String filterName;
     private Map<String, String> initParameters;
 

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterHolder.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterHolder.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.serverless.proxy.internal.servlet;
+
+import javax.servlet.*;
+import java.util.*;
+
+/**
+ * Wrapper for a servlet filter object. This object includes the filter itself, the filter name, the initialization
+ * parameters, as well as the registration object with its mappings. Filter holders are stored in the <code>AwsServletContext</code>
+ * object and are used by the by the <code>FilterChainHandler</code> object to process a request.
+ */
+public class FilterHolder {
+
+    //-------------------------------------------------------------
+    // Variables - Private
+    //-------------------------------------------------------------
+
+    private  Filter filter;
+    private  FilterConfig filterConfig;
+    private  Registration registration;
+    private String filterName;
+    private Map<String, String> initParameters;
+
+    private ServletContext servletContext;
+    private boolean filterInitialized;
+
+    //-------------------------------------------------------------
+    // Constructors
+    //-------------------------------------------------------------
+
+    /**
+     * Creates a new filter holder for the given Filter object. The object is initialized with an empty map of parameters
+     * and a registration with no mappings
+     * @param name The filter name
+     * @param newFilter The filter object to be registered against the name
+     * @param context The ServletContext this object was initialized by
+     */
+    public FilterHolder(String name, Filter newFilter, ServletContext context) {
+        filterName = name;
+        filter = newFilter;
+        servletContext = context;
+        initParameters = new HashMap<>();
+        registration = new Registration();
+        filterInitialized = false;
+    }
+
+    //-------------------------------------------------------------
+    // Methods - Public
+    //-------------------------------------------------------------
+
+    /**
+     * Checks whether the filter this holder is responsible for has been initialized. This method should be checked before
+     * calling a filter, if it returns false then you should call the <code>init</code> method.
+     * @return True if the filter has been initialized before, false otherwise
+     */
+    public boolean isFilterInitialized() {
+        return filterInitialized;
+    }
+
+    /**
+     * Initializes the wrapped filter and sets the <code>isFilterInitialized</code> property to true. This should be called
+     * before invoking a filter if the result of the <code>isFilterInitialized()</code> method is false.
+     * @throws ServletException Propagates any servlet exception thrown by the filter initialization
+     */
+    public void init() throws ServletException {
+        this.getFilter().init(filterConfig);
+        this.filterInitialized = true;
+    }
+
+
+    /**
+     * Returns the filter object
+     * @return the filter object
+     */
+    public Filter getFilter() {
+        return filter;
+    }
+
+    /**
+     * The filter config object implementation. This is the default <code>Config</code> object implemented in this file
+     * @return The filter config object
+     */
+    public FilterConfig getFilterConfig() {
+        return filterConfig;
+    }
+
+    /**
+     * Returns the Registration object for the filter. The <code>Registration</code> object defined in this file implements
+     * both <code>FilterRegistration</code> and <code>FilterRegistration.Dynamic</code>
+     * @return The registration obejct
+     */
+    public Registration getRegistration() {
+        return registration;
+    }
+
+    /**
+     * The name associated with the filter
+     * @return
+     */
+    public String getFilterName() {
+        return filterName;
+    }
+
+    /**
+     * The map of initialization parameters passed to the filter
+     * @return
+     */
+    public Map<String, String> getInitParameters() {
+        return initParameters;
+    }
+
+    /**
+     * The servlet context that initialized the filter
+     * @return
+     */
+    public ServletContext getServletContext() {
+        return servletContext;
+    }
+
+    /**
+     * Registration class for the filter. This object stores the servlet names and the url patterns the filter is
+     * associated with.
+     */
+    protected class Registration implements FilterRegistration.Dynamic {
+        private List<String> urlPatterns;
+        private List<DispatcherType> dispatcherTypes;
+        private boolean asyncSupported;
+
+        public Registration() {
+            urlPatterns = new ArrayList<>();
+            dispatcherTypes = new ArrayList<>();
+            asyncSupported = false;
+        }
+
+        @Override
+        public void addMappingForServletNames(EnumSet<DispatcherType> types, boolean isLast, String... servlets) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Collection<String> getServletNameMappings() {
+            return null;
+        }
+
+        @Override
+        public void addMappingForUrlPatterns(EnumSet<DispatcherType> types, boolean isLast, String... patterns) {
+            if (types == null) {
+                dispatcherTypes.add(DispatcherType.REQUEST);
+            } else {
+                dispatcherTypes.addAll(types);
+            }
+
+            for (String mapping : patterns) {
+                if (!validateMappingPath(mapping)) {
+                    throw new IllegalArgumentException(
+                            "Invalid path mapping, wildcards should be the last part of a path: " + mapping);
+                }
+            }
+
+            if (isLast) {
+                urlPatterns.addAll(Arrays.asList(patterns));
+            } else {
+                List<String> newUrlList = new ArrayList<>();
+                newUrlList.addAll(Arrays.asList(patterns));
+                newUrlList.addAll(urlPatterns);
+                urlPatterns = newUrlList;
+            }
+        }
+
+        /**
+         * Validates a path mapping sent to the registration object. This method currently only checks for path parts
+         * after a wildcard.
+         * @param mapping The mapping path to be validated
+         * @return True if this is a valid mapping, false otherwise.
+         */
+        private boolean validateMappingPath(String mapping) {
+            String[] parts = mapping.split(FilterChainManager.PATH_PART_SEPARATOR);
+
+            int wildcardPosition = -1;
+            for (int i = 0; i < parts.length; i++) {
+                if (wildcardPosition > -1 && i > wildcardPosition) {
+                    return false;
+                }
+                if (parts[i].trim().equals("*")) {
+                    wildcardPosition = i;
+                }
+            }
+            return true;
+        }
+
+
+        @Override
+        public Collection<String> getUrlPatternMappings() {
+            return urlPatterns;
+        }
+
+        @Override
+        public void setAsyncSupported(boolean b) {
+            asyncSupported = b;
+        }
+
+        @Override
+        public String getName() {
+            return filterName;
+        }
+
+        @Override
+        public String getClassName() {
+            return filter.getClass().getName();
+        }
+
+        @Override
+        public boolean setInitParameter(String s, String s1) {
+            if (initParameters.get(s) != null) {
+                return false;
+            }
+            initParameters.put(s, s1);
+            return true;
+        }
+
+        @Override
+        public String getInitParameter(String s) {
+            return initParameters.get(s);
+        }
+
+        @Override
+        public Set<String> setInitParameters(Map<String, String> map) {
+            Set<String> conflicts = new LinkedHashSet<>();
+            for (String newParamKey : map.keySet()) {
+                if (initParameters.get(newParamKey) != null) {
+                    conflicts.add(newParamKey);
+                } else {
+                    initParameters.put(newParamKey, map.get(newParamKey));
+                }
+            }
+            return conflicts;
+        }
+
+        @Override
+        public Map<String, String> getInitParameters() {
+            return initParameters;
+        }
+
+        public List<DispatcherType> getDispatcherTypes() {
+            return dispatcherTypes;
+        }
+    }
+
+    /**
+     * Default implementation of the <code>FilterConfig</code> object.
+     */
+    class Config implements FilterConfig {
+        @Override
+        public String getFilterName() {
+            return filterName;
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            return servletContext;
+        }
+
+        @Override
+        public String getInitParameter(String s) {
+            return initParameters.get(s);
+        }
+
+        @Override
+        public Enumeration<String> getInitParameterNames() {
+            return Collections.enumeration(initParameters.keySet());
+        }
+    }
+}

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/filters/UrlPathValidator.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/filters/UrlPathValidator.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.serverless.proxy.internal.servlet.filters;
+
+import javax.servlet.*;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+/**
+ * Simple path validator filter. This is a default implementation to prevent malformed paths from hitting the framework
+ * app. This applies to all paths by default
+ */
+@WebFilter(filterName = "UrlPathValidator", urlPatterns = {"/*"})
+public class UrlPathValidator implements Filter {
+    public static final int DEFAULT_ERROR_CODE = 404;
+    public static final Pattern PATH_PATTERN = Pattern.compile("^(/[-\\w:@&?=+,.!/~*'%$_;]*)?$");
+    private int invalidStatusCode;
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        if (filterConfig.getInitParameter("invalid_status_code") != null) {
+            String statusCode = filterConfig.getInitParameter("invalid_status_code");
+            try {
+                invalidStatusCode = Integer.parseInt(statusCode);
+            } catch (NumberFormatException e) {
+                invalidStatusCode = DEFAULT_ERROR_CODE;
+            }
+        }
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        // the getServletPath method of the AwsProxyHttpServletRequest returns the request path
+        String path = ((HttpServletRequest)servletRequest).getServletPath();
+        if (path == null) {
+            setErrorResponse(servletResponse);
+            return;
+        }
+
+        if (!PATH_PATTERN.matcher(path).matches()) {
+            setErrorResponse(servletResponse);
+            return;
+        }
+
+        // Logic taken from the Apache UrlValidator. I opted not to include Apache lib as a dependency to save space
+        // in the final Lambda function package
+        int slashCount = countStrings("/", path);
+        int dot2Count = countStrings("..", path);
+        int slash2Count = countStrings("//", path);
+        if (dot2Count > 0 && (slashCount - slash2Count - 1) <= dot2Count){
+            setErrorResponse(servletResponse);
+            return;
+        }
+
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    private void setErrorResponse(ServletResponse resp) {
+        ((HttpServletResponse)resp).setStatus(invalidStatusCode);
+    }
+
+    private int countStrings(String needle, String haystack) {
+        int curIndex = 0;
+        int stringCount = 0;
+
+        while (curIndex != -1) {
+            curIndex = haystack.indexOf(needle, curIndex);
+            if (curIndex > -1) {
+                curIndex++;
+                stringCount++;
+            }
+        }
+        return stringCount;
+    }
+}

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/filters/UrlPathValidator.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/filters/UrlPathValidator.java
@@ -25,9 +25,26 @@ import java.util.regex.Pattern;
  */
 @WebFilter(filterName = "UrlPathValidator", urlPatterns = {"/*"})
 public class UrlPathValidator implements Filter {
+
+    //-------------------------------------------------------------
+    // Constants
+    //-------------------------------------------------------------
+
     public static final int DEFAULT_ERROR_CODE = 404;
     public static final Pattern PATH_PATTERN = Pattern.compile("^(/[-\\w:@&?=+,.!/~*'%$_;]*)?$");
+
+
+    //-------------------------------------------------------------
+    // Variables - Private
+    //-------------------------------------------------------------
+
     private int invalidStatusCode;
+
+
+    //-------------------------------------------------------------
+    // Implementation - Filter
+    //-------------------------------------------------------------
+
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
@@ -40,6 +57,7 @@ public class UrlPathValidator implements Filter {
             }
         }
     }
+
 
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
@@ -68,14 +86,21 @@ public class UrlPathValidator implements Filter {
         filterChain.doFilter(servletRequest, servletResponse);
     }
 
+
     @Override
     public void destroy() {
 
     }
 
+
+    //-------------------------------------------------------------
+    // Methods - Private
+    //-------------------------------------------------------------
+
     private void setErrorResponse(ServletResponse resp) {
         ((HttpServletResponse)resp).setStatus(invalidStatusCode);
     }
+
 
     private int countStrings(String needle, String haystack) {
         int curIndex = 0;

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/filters/UrlPathValidator.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/filters/UrlPathValidator.java
@@ -32,6 +32,7 @@ public class UrlPathValidator implements Filter {
 
     public static final int DEFAULT_ERROR_CODE = 404;
     public static final Pattern PATH_PATTERN = Pattern.compile("^(/[-\\w:@&?=+,.!/~*'%$_;]*)?$");
+    public static final String PARAM_INVALID_STATUS_CODE = "invalid_status_code";
 
 
     //-------------------------------------------------------------
@@ -48,11 +49,12 @@ public class UrlPathValidator implements Filter {
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
-        if (filterConfig.getInitParameter("invalid_status_code") != null) {
-            String statusCode = filterConfig.getInitParameter("invalid_status_code");
+        if (filterConfig.getInitParameter(PARAM_INVALID_STATUS_CODE) != null) {
+            String statusCode = filterConfig.getInitParameter(PARAM_INVALID_STATUS_CODE);
             try {
                 invalidStatusCode = Integer.parseInt(statusCode);
             } catch (NumberFormatException e) {
+                // TODO: Log
                 invalidStatusCode = DEFAULT_ERROR_CODE;
             }
         }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/testutils/AwsProxyRequestBuilder.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/testutils/AwsProxyRequestBuilder.java
@@ -16,6 +16,8 @@ import com.amazonaws.serverless.proxy.internal.model.ApiGatewayAuthorizerContext
 import com.amazonaws.serverless.proxy.internal.model.ApiGatewayRequestContext;
 import com.amazonaws.serverless.proxy.internal.model.ApiGatewayRequestIdentity;
 import com.amazonaws.serverless.proxy.internal.model.AwsProxyRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -31,6 +33,7 @@ public class AwsProxyRequestBuilder {
     //-------------------------------------------------------------
 
     private AwsProxyRequest request;
+    private ObjectMapper mapper;
 
 
     //-------------------------------------------------------------
@@ -48,6 +51,8 @@ public class AwsProxyRequestBuilder {
 
 
     public AwsProxyRequestBuilder(String path, String httpMethod) {
+        this.mapper = new ObjectMapper();
+
         this.request = new AwsProxyRequest();
         this.request.setHttpMethod(httpMethod);
         this.request.setPath(path);
@@ -123,6 +128,18 @@ public class AwsProxyRequestBuilder {
     public AwsProxyRequestBuilder body(String body) {
         this.request.setBody(body);
         return this;
+    }
+
+    public AwsProxyRequestBuilder body(Object body) {
+        if (request.getHeaders() != null && request.getHeaders().get(HttpHeaders.CONTENT_TYPE).equals(MediaType.APPLICATION_JSON)) {
+            try {
+                return body(mapper.writeValueAsString(body));
+            } catch (JsonProcessingException e) {
+                throw new UnsupportedOperationException("Could not serialize object: " + e.getMessage());
+            }
+        } else {
+            throw new UnsupportedOperationException("Unsupported content type in request");
+        }
     }
 
 

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/testutils/AwsProxyRequestBuilder.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/testutils/AwsProxyRequestBuilder.java
@@ -63,6 +63,11 @@ public class AwsProxyRequestBuilder {
     // Methods - Public
     //-------------------------------------------------------------
 
+    public AwsProxyRequestBuilder stage(String stageName) {
+        this.request.getRequestContext().setStage(stageName);
+        return this;
+    }
+
     public AwsProxyRequestBuilder method(String httpMethod) {
         this.request.setHttpMethod(httpMethod);
         return this;

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsFilterChainManagerTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsFilterChainManagerTest.java
@@ -1,0 +1,29 @@
+package com.amazonaws.serverless.proxy.internal.servlet;
+
+import com.amazonaws.serverless.proxy.internal.testutils.MockLambdaContext;
+import com.amazonaws.services.lambda.runtime.Context;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.servlet.ServletContext;
+
+import static org.junit.Assert.*;
+
+public class AwsFilterChainManagerTest {
+
+    private static AwsFilterChainManager chainManager;
+    private static Context lambdaContext = new MockLambdaContext();
+
+    @BeforeClass
+    public static void setUp() {
+        ServletContext context = AwsServletContext.getInstance(lambdaContext);
+        chainManager = new AwsFilterChainManager((AwsServletContext)context);
+    }
+
+    @Test
+    public void paths_pathMatches_validPaths() {
+        assertTrue(chainManager.pathMatches("/users/123123123", "/users/*"));
+        assertTrue(chainManager.pathMatches("/apis/123/methods", "/apis/*"));
+        assertTrue(chainManager.pathMatches("/very/long/path/with/sub/resources", "/*"));
+    }
+}

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsFilterChainManagerTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsFilterChainManagerTest.java
@@ -1,11 +1,15 @@
 package com.amazonaws.serverless.proxy.internal.servlet;
 
+import com.amazonaws.serverless.proxy.internal.testutils.AwsProxyRequestBuilder;
 import com.amazonaws.serverless.proxy.internal.testutils.MockLambdaContext;
 import com.amazonaws.services.lambda.runtime.Context;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import javax.servlet.ServletContext;
+import javax.servlet.*;
+
+import java.io.IOException;
+import java.util.EnumSet;
 
 import static org.junit.Assert.*;
 
@@ -17,7 +21,15 @@ public class AwsFilterChainManagerTest {
     @BeforeClass
     public static void setUp() {
         ServletContext context = AwsServletContext.getInstance(lambdaContext);
-        chainManager = new AwsFilterChainManager((AwsServletContext)context);
+
+        FilterRegistration.Dynamic reg = context.addFilter("Filter1", new MockFilter());
+        reg.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/first/second");
+        FilterRegistration.Dynamic reg2 = context.addFilter("Filter2", new MockFilter());
+        reg2.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/second/*");
+        FilterRegistration.Dynamic reg3 = context.addFilter("Filter3", new MockFilter());
+        reg3.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/third/fourth/*");
+
+        chainManager = new AwsFilterChainManager((AwsServletContext) context);
     }
 
     @Test
@@ -25,5 +37,131 @@ public class AwsFilterChainManagerTest {
         assertTrue(chainManager.pathMatches("/users/123123123", "/users/*"));
         assertTrue(chainManager.pathMatches("/apis/123/methods", "/apis/*"));
         assertTrue(chainManager.pathMatches("/very/long/path/with/sub/resources", "/*"));
+
+        assertFalse(chainManager.pathMatches("/false/api", "/true/*"));
+        assertFalse(chainManager.pathMatches("/first/second/third", "/first/third/*"));
+        assertFalse(chainManager.pathMatches("/first/second/third", "/first/third/second"));
+    }
+
+    @Test
+    public void paths_pathMatches_invalidPaths() {
+        // I expect we'd want to run filters on these requests, especially the ones that look invalid
+        assertTrue(chainManager.pathMatches("_%Garbled%20Path_%", "/*"));
+        assertTrue(chainManager.pathMatches("<script>alert('message');</script>", "/*"));
+
+        assertFalse(chainManager.pathMatches("<script>alert('message');</script>", "/test/*"));
+    }
+
+    @Test
+    public void cacheKey_compare_samePath() {
+        FilterChainManager.TargetCacheKey cacheKey = new FilterChainManager.TargetCacheKey();
+        cacheKey.setDispatcherType(DispatcherType.REQUEST);
+        cacheKey.setTargetPath("/first/path");
+
+        FilterChainManager.TargetCacheKey secondCacheKey = new FilterChainManager.TargetCacheKey();
+        secondCacheKey.setDispatcherType(DispatcherType.REQUEST);
+        secondCacheKey.setTargetPath("/first/path");
+
+        assertEquals(cacheKey.hashCode(), secondCacheKey.hashCode());
+        assertTrue(cacheKey.equals(secondCacheKey));
+    }
+
+    @Test
+    public void cacheKey_compare_differentDispatcher() {
+        FilterChainManager.TargetCacheKey cacheKey = new FilterChainManager.TargetCacheKey();
+        cacheKey.setDispatcherType(DispatcherType.REQUEST);
+        cacheKey.setTargetPath("/first/path");
+
+        FilterChainManager.TargetCacheKey secondCacheKey = new FilterChainManager.TargetCacheKey();
+        secondCacheKey.setDispatcherType(DispatcherType.ASYNC);
+        secondCacheKey.setTargetPath("/first/path");
+
+        assertNotEquals(cacheKey.hashCode(), secondCacheKey.hashCode());
+        assertFalse(cacheKey.equals(secondCacheKey));
+    }
+
+    @Test
+    public void cacheKey_compare_additionalChars() {
+        FilterChainManager.TargetCacheKey cacheKey = new FilterChainManager.TargetCacheKey();
+        cacheKey.setDispatcherType(DispatcherType.REQUEST);
+        cacheKey.setTargetPath("/first/path");
+
+        FilterChainManager.TargetCacheKey secondCacheKey = new FilterChainManager.TargetCacheKey();
+        secondCacheKey.setDispatcherType(DispatcherType.REQUEST);
+        secondCacheKey.setTargetPath("/first/path/");
+        assertEquals(cacheKey.hashCode(), secondCacheKey.hashCode());
+        assertTrue(cacheKey.equals(secondCacheKey));
+
+        secondCacheKey.setTargetPath(" /first/path");
+        assertEquals(cacheKey.hashCode(), secondCacheKey.hashCode());
+        assertTrue(cacheKey.equals(secondCacheKey));
+
+        secondCacheKey.setTargetPath("first/path/");
+        assertEquals(cacheKey.hashCode(), secondCacheKey.hashCode());
+        assertTrue(cacheKey.equals(secondCacheKey));
+    }
+
+    @Test
+    public void filterChain_getFilterChain_subsetOfFilters() {
+        AwsProxyHttpServletRequest req = new AwsProxyHttpServletRequest(
+            new AwsProxyRequestBuilder("/first/second", "GET").build(), lambdaContext, null
+        );
+        FilterChainHolder fcHolder = chainManager.getFilterChain(req);
+        assertEquals(1, fcHolder.filterCount());
+        assertEquals("Filter1", fcHolder.getFilter(0).getFilterName());
+
+        req = new AwsProxyHttpServletRequest(
+                new AwsProxyRequestBuilder("/second/mime", "GET").build(), lambdaContext, null
+        );
+        fcHolder = chainManager.getFilterChain(req);
+        assertEquals(1, fcHolder.filterCount());
+        assertEquals("Filter2", fcHolder.getFilter(0).getFilterName());
+
+        req = new AwsProxyHttpServletRequest(
+                new AwsProxyRequestBuilder("/second/mime/third", "GET").build(), lambdaContext, null
+        );
+        fcHolder = chainManager.getFilterChain(req);
+        assertEquals(1, fcHolder.filterCount());
+        assertEquals("Filter2", fcHolder.getFilter(0).getFilterName());
+    }
+
+    @Test
+    public void filterChain_getFilterChain_multipleFilters() {
+        AwsProxyHttpServletRequest req = new AwsProxyHttpServletRequest(
+                new AwsProxyRequestBuilder("/second/important", "GET").build(), lambdaContext, null
+        );
+        FilterRegistration.Dynamic reg = req.getServletContext().addFilter("Filter4", new MockFilter());
+        reg.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/second/*");
+        FilterChainHolder fcHolder = chainManager.getFilterChain(req);
+        assertEquals(2, fcHolder.filterCount());
+        assertEquals("Filter2", fcHolder.getFilter(0).getFilterName());
+        assertEquals("Filter4", fcHolder.getFilter(1).getFilterName());
+
+        reg = req.getServletContext().addFilter("Filter5", new MockFilter());
+        reg.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), false, "/second/*");
+        fcHolder = chainManager.getFilterChain(req);
+        assertEquals(3, fcHolder.filterCount());
+        assertEquals("Filter2", fcHolder.getFilter(0).getFilterName());
+        assertEquals("Filter4", fcHolder.getFilter(1).getFilterName());
+        assertEquals("Filter5", fcHolder.getFilter(2).getFilterName());
+    }
+
+    private static class MockFilter implements Filter {
+
+        @Override
+        public void init(FilterConfig filterConfig) throws ServletException {
+            System.out.println("Init");
+        }
+
+        @Override
+        public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+            System.out.println("DoFilter");
+            filterChain.doFilter(servletRequest, servletResponse);
+        }
+
+        @Override
+        public void destroy() {
+            System.out.println("Destroy");
+        }
     }
 }

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequestTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequestTest.java
@@ -13,6 +13,8 @@ import static org.junit.Assert.*;
 
 import java.util.AbstractMap;
 import java.util.List;
+import java.util.Map;
+
 
 public class AwsHttpServletRequestTest {
 
@@ -22,6 +24,8 @@ public class AwsHttpServletRequestTest {
             .header(HttpHeaders.COOKIE, "yummy_cookie=choco; tasty_cookie=strawberry").build();
     private static final AwsProxyRequest complexAcceptHeader = new AwsProxyRequestBuilder("/accept", "GET")
             .header(HttpHeaders.ACCEPT, "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8").build();
+    private static final AwsProxyRequest queryString = new AwsProxyRequestBuilder("/test", "GET")
+            .queryString("one", "two").queryString("three", "four").build();
 
     private static final MockLambdaContext mockContext = new MockLambdaContext();
 
@@ -29,7 +33,7 @@ public class AwsHttpServletRequestTest {
     public void headers_parseHeaderValue_multiValue() {
         AwsProxyHttpServletRequest request = new AwsProxyHttpServletRequest(contentTypeRequest, mockContext, null);
         // I'm also using this to double-check that I can get a header ignoring case
-        List<AbstractMap.SimpleEntry<String, String>> values = request.parseHeaderValue(request.getHeader("content-type"));
+        List<Map.Entry<String, String>> values = request.parseHeaderValue(request.getHeader("content-type"));
 
         assertEquals(2, values.size());
         assertEquals("application/xml", values.get(0).getValue());
@@ -42,7 +46,7 @@ public class AwsHttpServletRequestTest {
     @Test
     public void headers_parseHeaderValue_validMultipleCookie() {
         AwsProxyHttpServletRequest request = new AwsProxyHttpServletRequest(validCookieRequest, mockContext, null);
-        List<AbstractMap.SimpleEntry<String, String>> values = request.parseHeaderValue(request.getHeader(HttpHeaders.COOKIE));
+        List<Map.Entry<String, String>> values = request.parseHeaderValue(request.getHeader(HttpHeaders.COOKIE));
 
         assertEquals(2, values.size());
         assertEquals("yummy_cookie", values.get(0).getKey());
@@ -54,7 +58,7 @@ public class AwsHttpServletRequestTest {
     @Test
     public void headers_parseHeaderValue_complexAccept() {
         AwsProxyHttpServletRequest request = new AwsProxyHttpServletRequest(complexAcceptHeader, mockContext, null);
-        List<AbstractMap.SimpleEntry<String, String>> values = request.parseHeaderValue(request.getHeader(HttpHeaders.ACCEPT));
+        List<Map.Entry<String, String>> values = request.parseHeaderValue(request.getHeader(HttpHeaders.ACCEPT));
 
         try {
             System.out.println(new ObjectMapper().writeValueAsString(values));
@@ -62,5 +66,15 @@ public class AwsHttpServletRequestTest {
             e.printStackTrace();
         }
         assertEquals(3, values.size());
+    }
+
+    @Test
+    public void queyrString_generateQueryString_validQuery() {
+        AwsProxyHttpServletRequest request = new AwsProxyHttpServletRequest(queryString, mockContext, null);
+
+        String parsedString = request.generateQueryString(queryString.getQueryStringParameters());
+        assertEquals("one=two&three=four", parsedString);
+
+        // TODO test url encoding, wrong parameters
     }
 }

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequestTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequestTest.java
@@ -1,0 +1,66 @@
+package com.amazonaws.serverless.proxy.internal.servlet;
+
+import com.amazonaws.serverless.proxy.internal.model.AwsProxyRequest;
+import com.amazonaws.serverless.proxy.internal.testutils.AwsProxyRequestBuilder;
+import com.amazonaws.serverless.proxy.internal.testutils.MockLambdaContext;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import javax.ws.rs.core.HttpHeaders;
+
+import static org.junit.Assert.*;
+
+import java.util.AbstractMap;
+import java.util.List;
+
+public class AwsHttpServletRequestTest {
+
+    private static final AwsProxyRequest contentTypeRequest = new AwsProxyRequestBuilder("/test", "GET")
+            .header(HttpHeaders.CONTENT_TYPE, "application/xml; charset=utf-8").build();
+    private static final AwsProxyRequest validCookieRequest = new AwsProxyRequestBuilder("/cookie", "GET")
+            .header(HttpHeaders.COOKIE, "yummy_cookie=choco; tasty_cookie=strawberry").build();
+    private static final AwsProxyRequest complexAcceptHeader = new AwsProxyRequestBuilder("/accept", "GET")
+            .header(HttpHeaders.ACCEPT, "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8").build();
+
+    private static final MockLambdaContext mockContext = new MockLambdaContext();
+
+    @Test
+    public void headers_parseHeaderValue_multiValue() {
+        AwsProxyHttpServletRequest request = new AwsProxyHttpServletRequest(contentTypeRequest, mockContext, null);
+        // I'm also using this to double-check that I can get a header ignoring case
+        List<AbstractMap.SimpleEntry<String, String>> values = request.parseHeaderValue(request.getHeader("content-type"));
+
+        assertEquals(2, values.size());
+        assertEquals("application/xml", values.get(0).getValue());
+        assertNull(values.get(0).getKey());
+
+        assertEquals("charset", values.get(1).getKey());
+        assertEquals("utf-8", values.get(1).getValue());
+    }
+
+    @Test
+    public void headers_parseHeaderValue_validMultipleCookie() {
+        AwsProxyHttpServletRequest request = new AwsProxyHttpServletRequest(validCookieRequest, mockContext, null);
+        List<AbstractMap.SimpleEntry<String, String>> values = request.parseHeaderValue(request.getHeader(HttpHeaders.COOKIE));
+
+        assertEquals(2, values.size());
+        assertEquals("yummy_cookie", values.get(0).getKey());
+        assertEquals("choco", values.get(0).getValue());
+        assertEquals("tasty_cookie", values.get(1).getKey());
+        assertEquals("strawberry", values.get(1).getValue());
+    }
+
+    @Test
+    public void headers_parseHeaderValue_complexAccept() {
+        AwsProxyHttpServletRequest request = new AwsProxyHttpServletRequest(complexAcceptHeader, mockContext, null);
+        List<AbstractMap.SimpleEntry<String, String>> values = request.parseHeaderValue(request.getHeader(HttpHeaders.ACCEPT));
+
+        try {
+            System.out.println(new ObjectMapper().writeValueAsString(values));
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        assertEquals(3, values.size());
+    }
+}

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/FilterHolderTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/FilterHolderTest.java
@@ -1,0 +1,24 @@
+package com.amazonaws.serverless.proxy.internal.servlet;
+
+import com.amazonaws.serverless.proxy.internal.servlet.filters.UrlPathValidator;
+import com.amazonaws.serverless.proxy.internal.testutils.MockLambdaContext;
+import com.amazonaws.services.lambda.runtime.Context;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class FilterHolderTest {
+    private static Context lambdaContext = new MockLambdaContext();
+
+    @Test
+    public void annotation_filterRegistration_pathValidator() {
+        FilterHolder holder = new FilterHolder(new UrlPathValidator(), AwsServletContext.getInstance(lambdaContext));
+
+        assertTrue(holder.isAnnotated());
+        assertNotEquals(UrlPathValidator.class.getName(), holder.getRegistration().getName());
+        assertEquals("UrlPathValidator", holder.getFilterName());
+        assertEquals("UrlPathValidator", holder.getRegistration().getName());
+        assertEquals(1, holder.getRegistration().getUrlPatternMappings().size());
+        assertEquals("/*", holder.getRegistration().getUrlPatternMappings().toArray()[0]);
+    }
+}

--- a/aws-serverless-java-container-spark/src/main/java/com/amazonaws/serverless/proxy/spark/embeddedserver/LambdaEmbeddedServer.java
+++ b/aws-serverless-java-container-spark/src/main/java/com/amazonaws/serverless/proxy/spark/embeddedserver/LambdaEmbeddedServer.java
@@ -62,7 +62,7 @@ public class LambdaEmbeddedServer
 
     public void configureWebSockets(Map<String, WebSocketHandlerWrapper> webSocketHandlers,
                                     Optional<Integer> webSocketIdleTimeoutMillis) {
-        // TODO: We do not support web sockets with API Gateway and Lambda
+        throw new UnsupportedOperationException();
     }
 
 

--- a/aws-serverless-java-container-spring/pom.xml
+++ b/aws-serverless-java-container-spring/pom.xml
@@ -78,6 +78,27 @@
             <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>5.4.1.Final</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.el</groupId>
+            <artifactId>javax.el-api</artifactId>
+            <version>2.2.4</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>2.2.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/aws-serverless-java-container-spring/pom.xml
+++ b/aws-serverless-java-container-spring/pom.xml
@@ -80,4 +80,17 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <!-- fork JVM before each spring test to make sure we have a clean context -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.9</version>
+                <configuration>
+                    <forkMode>always</forkMode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/aws-serverless-java-container-spring/src/main/java/com/amazonaws/serverless/proxy/spring/LambdaSpringApplicationInitializer.java
+++ b/aws-serverless-java-container-spring/src/main/java/com/amazonaws/serverless/proxy/spring/LambdaSpringApplicationInitializer.java
@@ -12,8 +12,10 @@
  */
 package com.amazonaws.serverless.proxy.spring;
 
+import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.ContextStoppedEvent;
 import org.springframework.web.WebApplicationInitializer;
 import org.springframework.web.context.ConfigurableWebApplicationContext;
 import org.springframework.web.context.ContextLoaderListener;
@@ -78,6 +80,13 @@ public class LambdaSpringApplicationInitializer implements WebApplicationInitial
         this.refreshContext = refreshContext;
     }
 
+    /**
+     * Given a request and response objects, triggers the filters set in the servlet context and
+     * @param request
+     * @param response
+     * @throws ServletException
+     * @throws IOException
+     */
     public void dispatch(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         currentResponse = response;

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/SpringAwsProxyTest.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/SpringAwsProxyTest.java
@@ -13,6 +13,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -30,6 +31,7 @@ import static org.junit.Assert.*;
 @ContextConfiguration(classes = {EchoSpringAppConfig.class})
 @WebAppConfiguration
 @TestExecutionListeners(inheritListeners = false, listeners = {DependencyInjectionTestExecutionListener.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class SpringAwsProxyTest {
     private static final String CUSTOM_HEADER_KEY = "x-custom-header";
     private static final String CUSTOM_HEADER_VALUE = "my-custom-value";

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/SpringServletContextTest.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/SpringServletContextTest.java
@@ -1,0 +1,102 @@
+package com.amazonaws.serverless.proxy.spring;
+
+import com.amazonaws.serverless.exceptions.ContainerInitializationException;
+import com.amazonaws.serverless.proxy.internal.LambdaContainerHandler;
+import com.amazonaws.serverless.proxy.internal.model.AwsProxyRequest;
+import com.amazonaws.serverless.proxy.internal.model.AwsProxyResponse;
+import com.amazonaws.serverless.proxy.internal.servlet.AwsServletContext;
+import com.amazonaws.serverless.proxy.internal.testutils.AwsProxyRequestBuilder;
+import com.amazonaws.serverless.proxy.internal.testutils.MockLambdaContext;
+import com.amazonaws.serverless.proxy.spring.echoapp.CustomHeaderFilter;
+import com.amazonaws.serverless.proxy.spring.echoapp.EchoSpringAppConfig;
+import com.amazonaws.serverless.proxy.spring.echoapp.model.MapResponseModel;
+import com.amazonaws.serverless.proxy.spring.echoapp.model.SingleValueModel;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.codec.binary.Base64;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterRegistration;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+// we don't use the spring annotations to pretend we are running in the actual container
+public class SpringServletContextTest {
+    private static final String STAGE = LambdaContainerHandler.SERVER_INFO + "/" + AwsServletContext.SERVLET_API_MAJOR_VERSION + "." + AwsServletContext.SERVLET_API_MINOR_VERSION;
+    private MockLambdaContext lambdaContext = new MockLambdaContext();
+
+    private static SpringLambdaContainerHandler<AwsProxyRequest, AwsProxyResponse> handler;
+
+    @BeforeClass
+    public static void setUp() {
+        try {
+            handler = SpringLambdaContainerHandler.getAwsProxyHandler(EchoSpringAppConfig.class);
+            handler.setRefreshContext(true);
+            handler.setStartupHandler(c -> {
+                FilterRegistration.Dynamic registration = c.addFilter("CustomHeaderFilter", CustomHeaderFilter.class);
+                // update the registration to map to a path
+                registration.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/*");
+                // servlet name mappings are disabled and will throw an exception
+            });
+        } catch (ContainerInitializationException e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void context_autowireValidContext_echoContext() {
+        AwsProxyRequest request = new AwsProxyRequestBuilder("/echo/servlet-context", "GET")
+                .json()
+                .stage(STAGE)
+                .build();
+
+        AwsProxyResponse output = handler.proxy(request, lambdaContext);
+        assertEquals(200, output.getStatusCode());
+        assertEquals("text/plain", output.getHeaders().get("Content-Type").split(";")[0]);
+        assertEquals(STAGE, output.getBody());
+    }
+
+    @Test
+    public void context_contextAware_contextEcho() {
+        AwsProxyRequest request = new AwsProxyRequestBuilder("/context/echo", "GET")
+                .json()
+                .stage(STAGE)
+                .build();
+
+        AwsProxyResponse output = handler.proxy(request, lambdaContext);
+        assertEquals(200, output.getStatusCode());
+        assertEquals("text/plain", output.getHeaders().get("Content-Type").split(";")[0]);
+        assertEquals(STAGE, output.getBody());
+    }
+
+    @Test
+    public void filter_customHeaderFilter_echoHeaders() {
+        AwsProxyRequest request = new AwsProxyRequestBuilder("/echo/headers", "GET")
+                .json()
+                .stage(STAGE)
+                .build();
+
+        AwsProxyResponse output = handler.proxy(request, lambdaContext);
+        assertNotNull(output.getHeaders());
+        assertTrue(output.getHeaders().size() > 0);
+        assertNotNull(output.getHeaders().get(CustomHeaderFilter.HEADER_NAME));
+        assertEquals(CustomHeaderFilter.HEADER_VALUE, output.getHeaders().get(CustomHeaderFilter.HEADER_NAME));
+    }
+}
+

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/SpringServletContextTest.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/SpringServletContextTest.java
@@ -32,7 +32,7 @@ public class SpringServletContextTest {
         try {
             handler = SpringLambdaContainerHandler.getAwsProxyHandler(EchoSpringAppConfig.class);
             handler.setRefreshContext(true);
-            handler.setStartupHandler(c -> {
+            handler.onStartup(c -> {
                 FilterRegistration.Dynamic registration = c.addFilter("CustomHeaderFilter", CustomHeaderFilter.class);
                 // update the registration to map to a path
                 registration.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/*");

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/SpringServletContextTest.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/SpringServletContextTest.java
@@ -9,29 +9,14 @@ import com.amazonaws.serverless.proxy.internal.testutils.AwsProxyRequestBuilder;
 import com.amazonaws.serverless.proxy.internal.testutils.MockLambdaContext;
 import com.amazonaws.serverless.proxy.spring.echoapp.CustomHeaderFilter;
 import com.amazonaws.serverless.proxy.spring.echoapp.EchoSpringAppConfig;
-import com.amazonaws.serverless.proxy.spring.echoapp.model.MapResponseModel;
-import com.amazonaws.serverless.proxy.spring.echoapp.model.SingleValueModel;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.codec.binary.Base64;
+import com.amazonaws.serverless.proxy.spring.echoapp.model.ValidatedUserModel;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
-import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.http.HttpStatus;
 
 import javax.servlet.DispatcherType;
 import javax.servlet.FilterRegistration;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import java.io.IOException;
 import java.util.EnumSet;
-import java.util.UUID;
 
 import static org.junit.Assert.*;
 
@@ -97,6 +82,19 @@ public class SpringServletContextTest {
         assertTrue(output.getHeaders().size() > 0);
         assertNotNull(output.getHeaders().get(CustomHeaderFilter.HEADER_NAME));
         assertEquals(CustomHeaderFilter.HEADER_VALUE, output.getHeaders().get(CustomHeaderFilter.HEADER_NAME));
+    }
+
+    @Test
+    public void filter_validationFilter_emptyName() {
+        ValidatedUserModel userModel = new ValidatedUserModel();
+        userModel.setFirstName("Test");
+        AwsProxyRequest request = new AwsProxyRequestBuilder("/context/user", "POST")
+                .json()
+                .body(userModel)
+                .build();
+
+        AwsProxyResponse output = handler.proxy(request, lambdaContext);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), output.getStatusCode());
     }
 }
 

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/ContextResource.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/ContextResource.java
@@ -1,0 +1,28 @@
+package com.amazonaws.serverless.proxy.spring.echoapp;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.ServletContextAware;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import javax.servlet.ServletContext;
+
+@RestController
+@EnableWebMvc
+@RequestMapping("/context")
+public class ContextResource implements ServletContextAware {
+    private ServletContext context;
+
+    @RequestMapping(path = "/echo", method= RequestMethod.GET)
+    public ResponseEntity<String> getContext() {
+        return new ResponseEntity<String>(this.context.getServerInfo(), HttpStatus.OK);
+    }
+
+    @Override
+    public void setServletContext(ServletContext servletContext) {
+        context = servletContext;
+    }
+}

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/ContextResource.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/ContextResource.java
@@ -1,7 +1,10 @@
 package com.amazonaws.serverless.proxy.spring.echoapp;
 
+import com.amazonaws.serverless.proxy.spring.echoapp.model.ValidatedUserModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,6 +12,8 @@ import org.springframework.web.context.ServletContextAware;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import javax.servlet.ServletContext;
+import javax.validation.Valid;
+import javax.ws.rs.core.MediaType;
 
 @RestController
 @EnableWebMvc
@@ -19,6 +24,16 @@ public class ContextResource implements ServletContextAware {
     @RequestMapping(path = "/echo", method= RequestMethod.GET)
     public ResponseEntity<String> getContext() {
         return new ResponseEntity<String>(this.context.getServerInfo(), HttpStatus.OK);
+    }
+
+    @RequestMapping(path = "/user", method=RequestMethod.POST, consumes = MediaType.APPLICATION_JSON)
+    public ResponseEntity<ValidatedUserModel> createUser(@Valid @RequestBody ValidatedUserModel newUser, BindingResult results) {
+
+        if (results.hasErrors()) {
+            System.out.println("Has errors");
+            return new ResponseEntity<ValidatedUserModel>(newUser, HttpStatus.BAD_REQUEST);
+        }
+        return new ResponseEntity<ValidatedUserModel>(newUser, HttpStatus.OK);
     }
 
     @Override

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/CustomHeaderFilter.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/CustomHeaderFilter.java
@@ -1,0 +1,31 @@
+package com.amazonaws.serverless.proxy.spring.echoapp;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+
+public class CustomHeaderFilter implements Filter {
+    public static final String HEADER_NAME = "X-Filter-Header";
+    public static final String HEADER_VALUE = "CustomHeaderFilter";
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        System.out.println("Called init on filter");
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        System.out.println("Called doFilter");
+        HttpServletResponse resp = (HttpServletResponse)servletResponse;
+        resp.addHeader(HEADER_NAME, HEADER_VALUE);
+
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+
+    @Override
+    public void destroy() {
+        System.out.println("Called destroy");
+    }
+}

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/EchoResource.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/EchoResource.java
@@ -4,11 +4,14 @@ import com.amazonaws.serverless.proxy.internal.RequestReader;
 import com.amazonaws.serverless.proxy.internal.model.ApiGatewayRequestContext;
 import com.amazonaws.serverless.proxy.spring.echoapp.model.MapResponseModel;
 import com.amazonaws.serverless.proxy.spring.echoapp.model.SingleValueModel;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.ServletContextAware;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
+import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import java.util.Enumeration;
 import java.util.Map;
@@ -18,6 +21,9 @@ import java.util.Random;
 @EnableWebMvc
 @RequestMapping("/echo")
 public class EchoResource {
+    @Autowired
+    ServletContext servletContext;
+
     @RequestMapping(path = "/headers", method = RequestMethod.GET)
     public MapResponseModel echoHeaders(@RequestHeader Map<String, String> allHeaders) {
         MapResponseModel headers = new MapResponseModel();
@@ -82,5 +88,10 @@ public class EchoResource {
         new Random().nextBytes(b);
 
         return new ResponseEntity<byte[]>(b, HttpStatus.OK);
+    }
+
+    @RequestMapping(path = "/servlet-context", method=RequestMethod.GET)
+    public ResponseEntity<String> getContext() {
+        return new ResponseEntity<String>(this.servletContext.getServerInfo(), HttpStatus.OK);
     }
 }

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/EchoSpringAppConfig.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/EchoSpringAppConfig.java
@@ -35,5 +35,4 @@ public class EchoSpringAppConfig {
     public MockLambdaContext lambdaContext() {
         return new MockLambdaContext();
     }
-
 }

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/EchoSpringAppConfig.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/EchoSpringAppConfig.java
@@ -2,14 +2,13 @@ package com.amazonaws.serverless.proxy.spring.echoapp;
 
 import com.amazonaws.serverless.exceptions.ContainerInitializationException;
 import com.amazonaws.serverless.proxy.internal.testutils.MockLambdaContext;
-import com.amazonaws.serverless.proxy.spring.LambdaSpringApplicationInitializer;
 import com.amazonaws.serverless.proxy.spring.SpringLambdaContainerHandler;
-import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.context.ConfigurableWebApplicationContext;
 
 @Configuration
@@ -34,5 +33,10 @@ public class EchoSpringAppConfig {
     @Bean
     public MockLambdaContext lambdaContext() {
         return new MockLambdaContext();
+    }
+
+    @Bean
+    public javax.validation.Validator localValidatorFactoryBean() {
+        return new LocalValidatorFactoryBean();
     }
 }

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/model/ValidatedUserModel.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/echoapp/model/ValidatedUserModel.java
@@ -1,0 +1,44 @@
+package com.amazonaws.serverless.proxy.spring.echoapp.model;
+
+import org.hibernate.validator.constraints.Email;
+import org.hibernate.validator.constraints.NotEmpty;
+
+import javax.validation.constraints.Size;
+
+public class ValidatedUserModel {
+    @NotEmpty
+    @Size(min=2, max=30)
+    private String firstName;
+
+    @NotEmpty
+    @Size(min=2, max=30)
+    private String lastName;
+
+    @NotEmpty
+    @Email
+    private String email;
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/samples/jersey/pet-store/src/main/java/com/amazonaws/serverless/sample/jersey/LambdaHandler.java
+++ b/samples/jersey/pet-store/src/main/java/com/amazonaws/serverless/sample/jersey/LambdaHandler.java
@@ -21,10 +21,10 @@ import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 
 public class LambdaHandler implements RequestHandler<AwsProxyRequest, AwsProxyResponse> {
-    private ResourceConfig jerseyApplication = new ResourceConfig()
+    private final ResourceConfig jerseyApplication = new ResourceConfig()
             .packages("com.amazonaws.serverless.sample.jersey")
             .register(JacksonFeature.class);
-    private JerseyLambdaContainerHandler<AwsProxyRequest, AwsProxyResponse> handler
+    private final JerseyLambdaContainerHandler<AwsProxyRequest, AwsProxyResponse> handler
             = JerseyLambdaContainerHandler.getAwsProxyHandler(jerseyApplication);
 
     @Override

--- a/samples/spring/pet-store/src/main/java/com/amazonaws/serverless/sample/spring/LambdaHandler.java
+++ b/samples/spring/pet-store/src/main/java/com/amazonaws/serverless/sample/spring/LambdaHandler.java
@@ -23,12 +23,10 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
  * Created by bulianis on 12/13/16.
  */
 public class LambdaHandler implements RequestHandler<AwsProxyRequest, AwsProxyResponse> {
-    SpringLambdaContainerHandler<AwsProxyRequest, AwsProxyResponse> handler;
-    boolean isinitialized = false;
+    private SpringLambdaContainerHandler<AwsProxyRequest, AwsProxyResponse> handler;
 
     public AwsProxyResponse handleRequest(AwsProxyRequest awsProxyRequest, Context context) {
-        if (!isinitialized) {
-            isinitialized = true;
+        if (handler == null) {
             try {
                 handler = SpringLambdaContainerHandler.getAwsProxyHandler(PetStoreSpringAppConfig.class);
             } catch (ContainerInitializationException e) {


### PR DESCRIPTION
Merging support for servlet filters into master branch. This should address issue #15. For containers that support the servlet specs you can use a `StartupHandler` to register filters in the servlet context:

```java
handler.setStartupHandler(c -> {
    FilterRegistration.Dynamic registration = c.addFilter("CustomHeaderFilter", CustomHeaderFilter.class);
    // update the registration to map to a path
    registration.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "/*");
    // servlet name mappings are disabled and will throw an exception
});
```

The container does NOT load filter implementations annotated with `@WebFilter` automatically, they still have to be registered in the `onStartup` method. This is to avoid impacting cold starts.