### PR TITLE
update samples' pom.xml bump version to use LATEST

### DIFF
--- a/samples/jersey/pet-store/pom.xml
+++ b/samples/jersey/pet-store/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.amazonaws.serverless</groupId>
             <artifactId>aws-serverless-java-container-jersey</artifactId>
-            <version>0.4</version>
+            <version>LATEST</version>
         </dependency>
 
         <dependency>

--- a/samples/jersey/pet-store/pom.xml
+++ b/samples/jersey/pet-store/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.amazonaws.serverless</groupId>
             <artifactId>aws-serverless-java-container-jersey</artifactId>
-            <version>0.1</version>
+            <version>0.4</version>
         </dependency>
 
         <dependency>

--- a/samples/spark/pet-store/pom.xml
+++ b/samples/spark/pet-store/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.amazonaws.serverless</groupId>
             <artifactId>aws-serverless-java-container-spark</artifactId>
-            <version>0.1</version>
+            <version>0.4</version>
         </dependency>
 
         <dependency>

--- a/samples/spark/pet-store/pom.xml
+++ b/samples/spark/pet-store/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.amazonaws.serverless</groupId>
             <artifactId>aws-serverless-java-container-spark</artifactId>
-            <version>0.4</version>
+            <version>LATEST</version>
         </dependency>
 
         <dependency>

--- a/samples/spring/pet-store/pom.xml
+++ b/samples/spring/pet-store/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.amazonaws.serverless</groupId>
             <artifactId>aws-serverless-java-container-spring</artifactId>
-            <version>0.1</version>
+            <version>0.4</version>
         </dependency>
 
         <dependency>

--- a/samples/spring/pet-store/pom.xml
+++ b/samples/spring/pet-store/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.amazonaws.serverless</groupId>
             <artifactId>aws-serverless-java-container-spring</artifactId>
-            <version>0.4</version>
+            <version>LATEST</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Fix version reference to this library (latest release, 0.4)

updated ref lets maven compile before `cloudformation package`'ing