### PR TITLE
[Minor change] Avoid a NullPointerException...

### DIFF
--- a/samples/spring/pet-store/src/main/java/com/amazonaws/serverless/sample/spring/StreamLambdaHandler.java
+++ b/samples/spring/pet-store/src/main/java/com/amazonaws/serverless/sample/spring/StreamLambdaHandler.java
@@ -28,6 +28,7 @@ public class StreamLambdaHandler implements RequestStreamHandler {
             } catch (ContainerInitializationException e) {
                 e.printStackTrace();
                 outputStream.close();
+                return;
             }
         }
 

--- a/samples/spring/pet-store/src/main/java/com/amazonaws/serverless/sample/spring/StreamLambdaHandler.java
+++ b/samples/spring/pet-store/src/main/java/com/amazonaws/serverless/sample/spring/StreamLambdaHandler.java
@@ -28,7 +28,7 @@ public class StreamLambdaHandler implements RequestStreamHandler {
             } catch (ContainerInitializationException e) {
                 e.printStackTrace();
                 outputStream.close();
-                return;
+                throw new RuntimeException(e);
             }
         }
 


### PR DESCRIPTION
Very small and non critical suggestion...
Correct me if I'm wrong, but if we don't do an early exit after line 30 in the rare case of an exception, it will throw an NPE on line 36 (37 above)
Another way would be to throw new IOException(e) instead of printStacktrace
Great library by the way!