### PR TITLE
Exclude JAX-RS and commons-fileupload

### DIFF
--- a/aws-serverless-java-container-core/pom.xml
+++ b/aws-serverless-java-container-core/pom.xml
@@ -48,6 +48,7 @@
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
             <version>1.3.2</version>
+            <optional>true</optional>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpmime -->


### PR DESCRIPTION
Since package size is a luxury in AWS Lambda, exclude JAX-RS and commons-fileupload by default, because not all applications will use it. (e.g. Spring MVC REST users don't use JAX-RS)
The applications who do use any of them, will depend on them in their project POM anyway.