### PR TITLE
Exclude commons-fileupload

### DIFF
--- a/aws-serverless-java-container-core/pom.xml
+++ b/aws-serverless-java-container-core/pom.xml
@@ -48,6 +48,7 @@
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
             <version>1.3.2</version>
+            <optional>true</optional>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpmime -->


### PR DESCRIPTION
Since package size is a luxury in AWS Lambda, exclude commons-fileupload by default, because not all applications will use it.
The applications who do use it, will depend on it in their project POM anyway.