### PR TITLE
Initialize filterConfig to avoid NPE

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterHolder.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterHolder.java
@@ -29,7 +29,7 @@ public class FilterHolder {
     //-------------------------------------------------------------
 
     private Filter filter;
-    private FilterConfig filterConfig;
+    private FilterConfig filterConfig = new Config();
     private Registration registration;
     private String filterName;
     private Map<String, String> initParameters;


### PR DESCRIPTION
As I mentioned on #68, I ran into an NPE when trying to configure a filter. Since there is no way to initialize `FilterHolder.filterConfig`, and it contains the `FilterHolder.Config` class, I just initialized with an instance of that. 