### PR TITLE
Bump in jackson dependency version

### DIFF
--- a/archetypes/jersey/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/jersey/src/main/resources/archetype-resources/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>com.amazonaws.serverless</groupId>
             <artifactId>aws-serverless-java-container-jersey</artifactId>
-            <version>1.0</version>
+            <version>1.0.1</version>
         </dependency>
 
         <dependency>

--- a/archetypes/spark/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/spark/src/main/resources/archetype-resources/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.amazonaws.serverless</groupId>
             <artifactId>aws-serverless-java-container-spark</artifactId>
-            <version>1.0</version>
+            <version>1.0.1</version>
         </dependency>
 
         <dependency>

--- a/archetypes/spring/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/spring/src/main/resources/archetype-resources/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.amazonaws.serverless</groupId>
             <artifactId>aws-serverless-java-container-spring</artifactId>
-            <version>1.0</version>
+            <version>1.0.1</version>
         </dependency>
 
         <dependency>

--- a/archetypes/springboot/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/springboot/src/main/resources/archetype-resources/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.amazonaws.serverless</groupId>
             <artifactId>aws-serverless-java-container-spring</artifactId>
-            <version>1.0</version>
+            <version>1.0.1</version>
         </dependency>
 
         <dependency>

--- a/aws-serverless-java-container-core/pom.xml
+++ b/aws-serverless-java-container-core/pom.xml
@@ -15,7 +15,7 @@
     </parent>
 
     <properties>
-        <jackson.version>2.9.3</jackson.version>
+        <jackson.version>2.9.4</jackson.version>
         <jaxrs.version>2.1</jaxrs.version>
         <servlet.version>3.1.0</servlet.version>
     </properties>

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
@@ -704,7 +704,7 @@ public class AwsProxyHttpServletRequest extends AwsHttpServletRequest {
 
 
     private String cleanUri(String uri) {
-        String finalUri = uri;
+        String finalUri = (uri == null ? "" : uri);
 
         if (!finalUri.startsWith("/")) {
             finalUri = "/" + finalUri;

--- a/aws-serverless-java-container-spark/src/test/java/com/amazonaws/serverless/proxy/spark/HelloWorldSparkStreamTest.java
+++ b/aws-serverless-java-container-spark/src/test/java/com/amazonaws/serverless/proxy/spark/HelloWorldSparkStreamTest.java
@@ -78,6 +78,21 @@ public class HelloWorldSparkStreamTest {
         }
     }
 
+    @Test
+    public void nullPathRequest_doesntFail_expectA404() {
+        InputStream req = new AwsProxyRequestBuilder().method("GET").path(null).buildStream();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try {
+            handler.proxyStream(req, outputStream, new MockLambdaContext());
+            AwsProxyResponse response = LambdaContainerHandler.getObjectMapper().readValue(outputStream.toByteArray(), AwsProxyResponse.class);
+
+            assertEquals(404, response.getStatusCode());
+        } catch (IOException e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
     private static void configureRoutes() {
         get("/hello", (req, res) -> {
             res.status(200);

--- a/aws-serverless-java-container-spring/pom.xml
+++ b/aws-serverless-java-container-spring/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <spring.version>5.0.3.RELEASE</spring.version>
         <spring-security.version>5.0.1.RELEASE</spring-security.version>
-        <jackson.version>2.9.3</jackson.version>
+        <jackson.version>2.9.4</jackson.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Preparing for 1.0.1 release to address critical vulnerability [CVE-2018-5968](https://nvd.nist.gov/vuln/detail/CVE-2018-5968) in Jackson dependency.