### PR TITLE
Upgrade spark to 2.7.2. Spark 2.7.2 fixes a security problem

### DIFF
--- a/archetypes/spark/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/spark/src/main/resources/archetype-resources/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <jackson.version>2.9.5</jackson.version>
-        <spark.version>2.7.1</spark.version>
+        <spark.version>2.7.2</spark.version>
     </properties>
 
     <dependencies>

--- a/aws-serverless-java-container-spark/pom.xml
+++ b/aws-serverless-java-container-spark/pom.xml
@@ -15,7 +15,7 @@
     </parent>
 
     <properties>
-        <spark.version>2.7.1</spark.version>
+        <spark.version>2.7.2</spark.version>
     </properties>
 
     <dependencies>

--- a/samples/spark/pet-store/pom.xml
+++ b/samples/spark/pet-store/pom.xml
@@ -27,7 +27,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <jackson.version>2.9.4</jackson.version>
-        <spark.version>2.7.1</spark.version>
+        <spark.version>2.7.2</spark.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
The framework currently uses spark 2.7.1.  Spark was updated in March 2018 to version 2.7.2.  The release notes say:

Spark 2.7.2 fixes a security problem in the serving of static files. It also adds support for specific keystore aliases and bumps Jetty to the latest version

This commit solely updates the version of spark in all three spark pom.xml files.