### PR TITLE
Allow registration of binary ContentTypes 

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
@@ -64,7 +64,7 @@ public class AwsProxyHttpServletResponseWriter extends ResponseWriter<AwsHttpSer
                 return LambdaContainerHandler.getContainerConfig().isBinaryContentType(contentType.substring(0, semidx));
             }
             else {
-                LambdaContainerHandler.getContainerConfig().isBinaryContentType(contentType);
+                return LambdaContainerHandler.getContainerConfig().isBinaryContentType(contentType);
             }
         }
         return false;

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
@@ -58,6 +58,15 @@ public class AwsProxyHttpServletResponseWriter extends ResponseWriter<AwsHttpSer
     }
 
     private boolean isBinary(String contentType) {
-        return contentType == null ? false : LambdaContainerHandler.getContainerConfig().isBinaryContentType(contentType);
+        if(contentType != null) {
+            int semidx = contentType.indexOf(';');
+            if(semidx >= 0) {
+                return LambdaContainerHandler.getContainerConfig().isBinaryContentType(contentType.substring(0, semidx));
+            }
+            else {
+                LambdaContainerHandler.getContainerConfig().isBinaryContentType(contentType);
+            }
+        }
+        return false;
     }
 }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
@@ -15,6 +15,7 @@ package com.amazonaws.serverless.proxy.internal.servlet;
 
 import com.amazonaws.serverless.exceptions.InvalidResponseObjectException;
 import com.amazonaws.serverless.proxy.ResponseWriter;
+import com.amazonaws.serverless.proxy.internal.LambdaContainerHandler;
 import com.amazonaws.serverless.proxy.internal.testutils.Timer;
 import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
 import com.amazonaws.services.lambda.runtime.Context;
@@ -39,7 +40,7 @@ public class AwsProxyHttpServletResponseWriter extends ResponseWriter<AwsHttpSer
         if (containerResponse.getAwsResponseBodyString() != null) {
             String responseString;
 
-            if (isValidUtf8(containerResponse.getAwsResponseBodyBytes())) {
+            if (!isBinary(containerResponse.getContentType()) && isValidUtf8(containerResponse.getAwsResponseBodyBytes())) {
                 responseString = containerResponse.getAwsResponseBodyString();
             } else {
                 responseString = Base64.getMimeEncoder().encodeToString(containerResponse.getAwsResponseBodyBytes());
@@ -54,5 +55,9 @@ public class AwsProxyHttpServletResponseWriter extends ResponseWriter<AwsHttpSer
 
         Timer.stop("SERVLET_RESPONSE_WRITE");
         return awsProxyResponse;
+    }
+
+    private boolean isBinary(String contentType) {
+        return contentType == null ? false : LambdaContainerHandler.getContainerConfig().isBinaryContentType(contentType);
     }
 }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/model/ContainerConfig.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/model/ContainerConfig.java
@@ -23,6 +23,7 @@ public class ContainerConfig {
         configuration.setUseStageAsServletContext(false);
         configuration.setValidFilePaths(DEFAULT_FILE_PATHS);
         configuration.setQueryStringCaseSensitive(false);
+        configuration.addBinaryContentTypes("application/octet-stream", "image/jpeg", "image/png", "image/gif");
 
         return configuration;
     }
@@ -223,20 +224,23 @@ public class ContainerConfig {
     }
 
     /**
-     * Configure specified content type as binary
+     * Configure specified content type(s) as binary
+     * @param contentTypes list of exact content types that will be considered as binary
      */
-    public void addBinaryContentType(String type) {
-        if(type != null) {
-            binaryContentTypes.add(type);
+    public void addBinaryContentTypes(String... contentTypes) {
+        if(contentTypes != null) {
+            for(String type: contentTypes) {
+                binaryContentTypes.add(type);
+            }
         }
     }
 
     /**
      * Determine if specified content type has been configured as binary
-     * @param type
+     * @param contentType content type to query
      * @return
      */
-    public boolean isBinaryContentType(String type) {
-        return binaryContentTypes.contains(type);
+    public boolean isBinaryContentType(String contentType) {
+        return contentType != null && binaryContentTypes.contains(contentType.trim());
     }
 }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/model/ContainerConfig.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/model/ContainerConfig.java
@@ -4,6 +4,7 @@ package com.amazonaws.serverless.proxy.model;
 import com.amazonaws.serverless.proxy.internal.servlet.AwsProxyHttpServletRequest;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 
@@ -38,6 +39,7 @@ public class ContainerConfig {
     private List<String> validFilePaths;
     private List<String> customDomainNames;
     private boolean queryStringCaseSensitive;
+    private final HashSet<String> binaryContentTypes = new HashSet<>();
 
     public ContainerConfig() {
         validFilePaths = new ArrayList<>();
@@ -218,5 +220,23 @@ public class ContainerConfig {
      */
     public void setQueryStringCaseSensitive(boolean queryStringCaseSensitive) {
         this.queryStringCaseSensitive = queryStringCaseSensitive;
+    }
+
+    /**
+     * Configure specified content type as binary
+     */
+    public void addBinaryContentType(String type) {
+        if(type != null) {
+            binaryContentTypes.add(type);
+        }
+    }
+
+    /**
+     * Determine if specified content type has been configured as binary
+     * @param type
+     * @return
+     */
+    public boolean isBinaryContentType(String type) {
+        return binaryContentTypes.contains(type);
     }
 }


### PR DESCRIPTION
Allow registration of binary content types in `ContainerConfig`, and skip the utf-8 scan when returning responses that match those content types in`AwsProxyHttpServletResponseWriter`. 

By default, register application/octet-stream, impage/[png|jpeg|gif] as binary content types.