### PR TITLE
Upgraded Spark to 2.8.0

### DIFF
--- a/archetypes/spark/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/spark/src/main/resources/archetype-resources/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <jackson.version>2.9.5</jackson.version>
-        <spark.version>2.7.2</spark.version>
+        <spark.version>2.8.0</spark.version>
     </properties>
 
     <dependencies>

--- a/aws-serverless-java-container-spark/pom.xml
+++ b/aws-serverless-java-container-spark/pom.xml
@@ -15,7 +15,7 @@
     </parent>
 
     <properties>
-        <spark.version>2.7.2</spark.version>
+        <spark.version>2.8.0</spark.version>
     </properties>
 
     <dependencies>

--- a/aws-serverless-java-container-spark/src/main/java/com/amazonaws/serverless/proxy/spark/embeddedserver/LambdaEmbeddedServerFactory.java
+++ b/aws-serverless-java-container-spark/src/main/java/com/amazonaws/serverless/proxy/spark/embeddedserver/LambdaEmbeddedServerFactory.java
@@ -3,6 +3,7 @@ package com.amazonaws.serverless.proxy.spark.embeddedserver;
 import com.amazonaws.serverless.proxy.internal.testutils.Timer;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import spark.ExceptionMapper;
 import spark.embeddedserver.EmbeddedServer;
 import spark.embeddedserver.EmbeddedServerFactory;
 import spark.route.Routes;
@@ -39,10 +40,10 @@ public class LambdaEmbeddedServerFactory implements EmbeddedServerFactory {
 
 
     @Override
-    public EmbeddedServer create(Routes routes, StaticFilesConfiguration staticFilesConfiguration, boolean multipleHandlers) {
+    public EmbeddedServer create(Routes routes, StaticFilesConfiguration staticFilesConfiguration, ExceptionMapper exceptionMapper, boolean multipleHandlers) {
         Timer.start("SPARK_SERVER_FACTORY_CREATE");
         if (embeddedServer == null) {
-            LambdaEmbeddedServerFactory.embeddedServer = new LambdaEmbeddedServer(routes, staticFilesConfiguration, multipleHandlers);
+            LambdaEmbeddedServerFactory.embeddedServer = new LambdaEmbeddedServer(routes, staticFilesConfiguration, exceptionMapper, multipleHandlers);
         }
         Timer.stop("SPARK_SERVER_FACTORY_CREATE");
         return embeddedServer;

--- a/aws-serverless-java-container-spark/src/test/java/com/amazonaws/serverless/proxy/spark/embeddedserver/LambdaEmbeddedServerTest.java
+++ b/aws-serverless-java-container-spark/src/test/java/com/amazonaws/serverless/proxy/spark/embeddedserver/LambdaEmbeddedServerTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.*;
 
 
 public class LambdaEmbeddedServerTest {
-    private static LambdaEmbeddedServer server = new LambdaEmbeddedServer(null, null, false);
+    private static LambdaEmbeddedServer server = new LambdaEmbeddedServer(null, null, null, false);
 
     @Test
     public void webSocket_configureWebSocket_noException() {

--- a/samples/spark/pet-store/pom.xml
+++ b/samples/spark/pet-store/pom.xml
@@ -27,14 +27,14 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <jackson.version>2.9.4</jackson.version>
-        <spark.version>2.7.2</spark.version>
+        <spark.version>2.8.0</spark.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.amazonaws.serverless</groupId>
             <artifactId>aws-serverless-java-container-spark</artifactId>
-            <version>[0.1,)</version>
+            <version>[0.2,)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.sparkjava/spark-core -->


### PR DESCRIPTION
Spark 2.8.0 was released on Sept 18, 2018.

There is only one breaking change between 2.7.2 and 2.8.0  This commit adds ExceptionMapper the to resolve.