### PR TITLE
Multi part form fix

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
@@ -25,6 +25,7 @@ import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.NullInputStream;
 import org.slf4j.Logger;
@@ -63,6 +64,7 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.io.File;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -685,7 +687,7 @@ public class AwsProxyHttpServletRequest extends AwsHttpServletRequest {
     }
 
 
-    @SuppressFBWarnings("FILE_UPLOAD_FILENAME")
+    @SuppressFBWarnings({"FILE_UPLOAD_FILENAME", "WEAK_FILENAMEUTILS"})
     private Map<String, Part> getMultipartFormParametersMap() {
         if (multipartFormParameters != null) {
             return multipartFormParameters;
@@ -701,7 +703,7 @@ public class AwsProxyHttpServletRequest extends AwsHttpServletRequest {
         try {
             List<FileItem> items = upload.parseRequest(this);
             for (FileItem item : items) {
-                String fileName = SecurityUtils.getValidFilePath(item.getName(), true);
+                String fileName = FilenameUtils.getName(item.getName());
                 AwsProxyRequestPart newPart = new AwsProxyRequestPart(item.get());
                 newPart.setName(fileName);
                 newPart.setSubmittedFileName(item.getFieldName());

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
@@ -64,7 +64,6 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.io.File;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;


### PR DESCRIPTION
Do not call SecurityUtils.getValidFilePath when processing a Multipart form as it will reject almost anything a user might put there. Just use the base filename