### PR TITLE
Use latest available Apache Struts2 GA 2.5.20 release

### DIFF
--- a/aws-serverless-java-container-core/pom.xml
+++ b/aws-serverless-java-container-core/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.3.3</version>
+            <version>1.4</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpmime -->

--- a/aws-serverless-java-container-struts2/pom.xml
+++ b/aws-serverless-java-container-struts2/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-to-slf4j</artifactId>
-            <version>2.10.0</version>
+            <version>2.11.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/aws-serverless-java-container-struts2/pom.xml
+++ b/aws-serverless-java-container-struts2/pom.xml
@@ -15,7 +15,7 @@
     </parent>
 
     <properties>
-        <struts2.version>2.5.18</struts2.version>
+        <struts2.version>2.5.20</struts2.version>
         <jackson.version>2.9.8</jackson.version>
     </properties>
 

--- a/aws-serverless-struts2-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/aws-serverless-struts2-archetype/src/main/resources/archetype-resources/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <struts2.version>2.5.17</struts2.version>
+        <struts2.version>2.5.20</struts2.version>
         <jackson.version>2.9.8</jackson.version>
         <junit.version>4.12</junit.version>
         <log4j.version>2.8.2</log4j.version>
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.jgeppert.struts2</groupId>
             <artifactId>struts2-aws-lambda-support-plugin</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
 
         <!-- bean validation based on hibernate validators-->

--- a/aws-serverless-struts2-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/aws-serverless-struts2-archetype/src/main/resources/archetype-resources/pom.xml
@@ -18,7 +18,7 @@
         <struts2.version>2.5.20</struts2.version>
         <jackson.version>2.9.8</jackson.version>
         <junit.version>4.12</junit.version>
-        <log4j.version>2.8.2</log4j.version>
+        <log4j.version>2.11.1</log4j.version>
     </properties>
 
     <dependencies>

--- a/samples/struts/pet-store/build.gradle
+++ b/samples/struts/pet-store/build.gradle
@@ -8,11 +8,11 @@ repositories {
 dependencies {
   compile (
           'com.amazonaws.serverless:aws-serverless-java-container-struts2:[1.0,)',
-          'org.apache.struts:struts2-convention-plugin:2.5.17',
-          'org.apache.struts:struts2-rest-plugin:2.5.17',
-          'org.apache.struts:struts2-bean-validation-plugin:2.5.17',
-          'org.apache.struts:struts2-junit-plugin:2.5.17',
-          'com.jgeppert.struts2:struts2-aws-lambda-support-plugin:1.0.0',
+          'org.apache.struts:struts2-convention-plugin:2.5.20',
+          'org.apache.struts:struts2-rest-plugin:2.5.20',
+          'org.apache.struts:struts2-bean-validation-plugin:2.5.20',
+          'org.apache.struts:struts2-junit-plugin:2.5.20',
+          'com.jgeppert.struts2:struts2-aws-lambda-support-plugin:1.1.0',
           'org.hibernate:hibernate-validator:4.3.2.Final',
           'com.fasterxml.jackson.core:jackson-databind:2.9.8',
           'org.apache.logging.log4j:log4j-core:2.8.2',

--- a/samples/struts/pet-store/pom.xml
+++ b/samples/struts/pet-store/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <struts2.version>2.5.17</struts2.version>
+        <struts2.version>2.5.20</struts2.version>
         <jackson.version>2.9.8</jackson.version>
         <junit.version>4.12</junit.version>
         <log4j.version>2.8.2</log4j.version>
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.jgeppert.struts2</groupId>
             <artifactId>struts2-aws-lambda-support-plugin</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
 
         <!-- bean validation based on hibernate validators-->

--- a/samples/struts/pet-store/pom.xml
+++ b/samples/struts/pet-store/pom.xml
@@ -29,7 +29,7 @@
         <struts2.version>2.5.20</struts2.version>
         <jackson.version>2.9.8</jackson.version>
         <junit.version>4.12</junit.version>
-        <log4j.version>2.8.2</log4j.version>
+        <log4j.version>2.11.1</log4j.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
* Use latest Struts2 version 2.5.20 in dependencies
* Use latest support plugin 1.1.0 with additional useful interceptors and predefined stack in samples and archetypes