### PR TITLE
Expose the Jersey injection manager

### DIFF
--- a/aws-serverless-java-container-jersey/src/main/java/com/amazonaws/serverless/proxy/jersey/JerseyLambdaContainerHandler.java
+++ b/aws-serverless-java-container-jersey/src/main/java/com/amazonaws/serverless/proxy/jersey/JerseyLambdaContainerHandler.java
@@ -34,6 +34,7 @@ import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
 import com.amazonaws.services.lambda.runtime.Context;
 
 import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.glassfish.jersey.process.internal.RequestScoped;
 import org.glassfish.jersey.server.ResourceConfig;
 
@@ -195,5 +196,13 @@ public class JerseyLambdaContainerHandler<RequestType, ResponseType> extends Aws
 
         Timer.stop("JERSEY_COLD_START_INIT");
         initialized = true;
+    }
+
+
+    public InjectionManager getInjectionManager() {
+        if (!initialized) {
+            initialize();
+        }
+        return jerseyFilter.getApplicationHandler().getInjectionManager();
     }
 }

--- a/aws-serverless-java-container-jersey/src/test/java/com/amazonaws/serverless/proxy/jersey/JerseyInjectionTest.java
+++ b/aws-serverless-java-container-jersey/src/test/java/com/amazonaws/serverless/proxy/jersey/JerseyInjectionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.serverless.proxy.jersey;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import javax.inject.Singleton;
+
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.Test;
+
+import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
+import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
+
+/**
+ * Test that one can access the Jersey injection manager
+ */
+public class JerseyInjectionTest {
+
+    // Test ressource binder
+    private static class ResourceBinder extends AbstractBinder {
+
+        @Override
+        protected void configure() {
+            bind(new JerseyInjectionTest()).to(JerseyInjectionTest.class).in(Singleton.class);
+        }
+
+    }
+
+    private static ResourceConfig app = new ResourceConfig().register(MultiPartFeature.class)
+                                                            .register(new ResourceBinder());
+
+    private static JerseyLambdaContainerHandler<AwsProxyRequest, AwsProxyResponse> handler = JerseyLambdaContainerHandler.getAwsProxyHandler(
+            app);
+
+    @Test
+    public void can_get_injected_resources() throws Exception {
+
+        JerseyInjectionTest instance1 = handler.getInjectionManager().getInstance(JerseyInjectionTest.class);
+        assertNotNull(instance1);
+
+        JerseyInjectionTest instance2 = handler.getInjectionManager().getInstance(JerseyInjectionTest.class);
+        assertEquals(instance1, instance2);
+
+    }
+}


### PR DESCRIPTION
Expose the Jersey injection manager to be able to use it outside of Jersey resources


*Description of changes:*

This PR just add a method on the `JerseyLambdaContainerHandler` that exposes the Jersey injections manager. It's very useful as it allows to use it to build the whole dependency tree. 

```java
// List of application bindings to configure injections, this
// allows to have different injection in tests
protected abstract List<Binder> binders();

public AbstractServiceHandler() {
  ResourceConfig jerseyApplication = new ResourceConfig()
                                             .packages("com.acme.jaxrs.resources");

  binders().forEach(jerseyApplication::register);

  handler = JerseyLambdaContainerHandler.getAwsProxyHandler(jerseyApplication);
  im = handler.getInjectionManager();
  ServiceFactory.setInstance(im.getInstance(Service.class));
}
```

If the lambda code also handles other type of event, the same injector can then be reused:

``` java
public String handleS3Request(S3Event s3Event) {
  Service service = im.getInstance(Service.class);
  return service.handleEvent(adapt(s3Event));
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
