### PR TITLE
Fix for content type probing for static files.

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContext.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContext.java
@@ -143,6 +143,10 @@ public class AwsServletContext
     @SuppressFBWarnings("PATH_TRAVERSAL_IN") // suppressing because we are using the getValidFilePath
     public String getMimeType(String s) {
         try {
+            File f = new File(s);
+            if (!f.isAbsolute()) {
+                s = "/tmp/" + f;
+            }
             String validatedPath = SecurityUtils.getValidFilePath(s);
             return Files.probeContentType(Paths.get(validatedPath));
         } catch (IOException e) {


### PR DESCRIPTION
*Issue #254*

*Description of changes:*
Prefix non-absolute paths with `"/tmp"` when probing MIME type. This is a working fix to #254 provided as an example, but may need some additional randomisation adding to the path to avoid any potential collision with actually existing files in /tmp. Also not yet compared to behaviour of frameworks other than Spring Boot.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
