### PR TITLE
Fixed issue where a 200 response is returned when server throws exception

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/AwsProxyExceptionHandler.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/AwsProxyExceptionHandler.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
@@ -31,7 +32,8 @@ import java.io.OutputStream;
 /**
  * Default implementation of the <code>ExceptionHandler</code> object that returns AwsProxyResponse objects.
  *
- * Returns application/json messages with a status code of 500 when the RequestReader failed to read the incoming event.
+ * Returns application/json messages with a status code of 500 when the RequestReader failed to read the incoming event
+ *  or if InternalServerErrorException is thrown.
  * For all other exceptions returns a 502. Responses are populated with a JSON object containing a message property.
  *
  * @see ExceptionHandler
@@ -76,7 +78,7 @@ public class AwsProxyExceptionHandler
         // adding a print stack trace in case we have no appender or we are running inside SAM local, where need the
         // output to go to the stderr.
         ex.printStackTrace();
-        if (ex instanceof InvalidRequestEventException) {
+        if (ex instanceof InvalidRequestEventException || ex instanceof InternalServerErrorException) {
             return new AwsProxyResponse(500, headers, getErrorJson(INTERNAL_SERVER_ERROR));
         } else {
             return new AwsProxyResponse(502, headers, getErrorJson(GATEWAY_TIMEOUT_ERROR));

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/LambdaContainerHandler.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/LambdaContainerHandler.java
@@ -215,9 +215,6 @@ public abstract class LambdaContainerHandler<RequestType, ResponseType, Containe
         } catch (JsonMappingException e) {
             log.error("Error while mapping object to RequestType class", e);
             getObjectMapper().writeValue(output, exceptionHandler.handle(e));
-        } catch (Exception e) {
-            log.error("Error while proxying request.", e);
-            getObjectMapper().writeValue(output, exceptionHandler.handle(e));
         } finally {
             output.flush();
             output.close();

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/LambdaContainerHandler.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/LambdaContainerHandler.java
@@ -215,6 +215,9 @@ public abstract class LambdaContainerHandler<RequestType, ResponseType, Containe
         } catch (JsonMappingException e) {
             log.error("Error while mapping object to RequestType class", e);
             getObjectMapper().writeValue(output, exceptionHandler.handle(e));
+        } catch (Exception e) {
+            log.error("Error while proxying request.", e);
+            getObjectMapper().writeValue(output, exceptionHandler.handle(e));
         } finally {
             output.flush();
             output.close();

--- a/aws-serverless-java-container-jersey/src/main/java/com/amazonaws/serverless/proxy/jersey/JerseyServletResponseWriter.java
+++ b/aws-serverless-java-container-jersey/src/main/java/com/amazonaws/serverless/proxy/jersey/JerseyServletResponseWriter.java
@@ -122,14 +122,8 @@ class JerseyServletResponseWriter
 
 
     public void failure(Throwable throwable) {
-        try {
-            log.error("failure", throwable);
-            jerseyLatch.countDown();
-            servletResponse.flushBuffer();
-        } catch (IOException e) {
-            log.error("Could not fail response", e);
-            throw new InternalServerErrorException(e);
-        }
+        log.error("failure", throwable);
+        throw new InternalServerErrorException("Jersey failed to process request", throwable);
     }
 
 

--- a/aws-serverless-java-container-jersey/src/test/java/com/amazonaws/serverless/proxy/jersey/EchoJerseyResource.java
+++ b/aws-serverless-java-container-jersey/src/test/java/com/amazonaws/serverless/proxy/jersey/EchoJerseyResource.java
@@ -24,6 +24,7 @@ import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
+import javax.inject.Inject;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -58,6 +59,9 @@ public class EchoJerseyResource {
 
     @Context
     SecurityContext securityCtx;
+
+    @Inject
+    JerseyDependency jerseyDependency;
 
     @Path("/decoded-param") @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/aws-serverless-java-container-jersey/src/test/java/com/amazonaws/serverless/proxy/jersey/JerseyDependency.java
+++ b/aws-serverless-java-container-jersey/src/test/java/com/amazonaws/serverless/proxy/jersey/JerseyDependency.java
@@ -1,0 +1,6 @@
+package com.amazonaws.serverless.proxy.jersey;
+
+// This class is used to test HK2 dependency injection.
+public class JerseyDependency {
+
+}

--- a/aws-serverless-java-container-jersey/src/test/java/com/amazonaws/serverless/proxy/jersey/JerseyInjectionTest.java
+++ b/aws-serverless-java-container-jersey/src/test/java/com/amazonaws/serverless/proxy/jersey/JerseyInjectionTest.java
@@ -30,7 +30,7 @@ import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
  */
 public class JerseyInjectionTest {
 
-    // Test ressource binder
+    // Test resource binder
     private static class ResourceBinder extends AbstractBinder {
 
         @Override

--- a/aws-serverless-java-container-jersey/src/test/java/com/amazonaws/serverless/proxy/jersey/JerseyParamEncodingTest.java
+++ b/aws-serverless-java-container-jersey/src/test/java/com/amazonaws/serverless/proxy/jersey/JerseyParamEncodingTest.java
@@ -11,7 +11,6 @@ import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
 import com.amazonaws.services.lambda.runtime.Context;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.glassfish.jersey.logging.LoggingFeature;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Ignore;
@@ -26,10 +25,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.logging.ConsoleHandler;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.logging.SimpleFormatter;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -69,6 +64,7 @@ public class JerseyParamEncodingTest {
     private static ObjectMapper objectMapper = new ObjectMapper();
     private static ResourceConfig app = new ResourceConfig().packages("com.amazonaws.serverless.proxy.jersey")
                                                             .register(MultiPartFeature.class)
+                                                            .register(new ResourceBinder())
                                                             .property("jersey.config.server.tracing.type", "ALL")
                                                             .property("jersey.config.server.tracing.threshold", "VERBOSE");
     private static JerseyLambdaContainerHandler<AwsProxyRequest, AwsProxyResponse> handler = JerseyLambdaContainerHandler.getAwsProxyHandler(app);

--- a/aws-serverless-java-container-jersey/src/test/java/com/amazonaws/serverless/proxy/jersey/ResourceBinder.java
+++ b/aws-serverless-java-container-jersey/src/test/java/com/amazonaws/serverless/proxy/jersey/ResourceBinder.java
@@ -1,0 +1,12 @@
+package com.amazonaws.serverless.proxy.jersey;
+
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+
+import javax.inject.Singleton;
+
+public class ResourceBinder extends AbstractBinder {
+    @Override
+    protected void configure() {
+        bind(new JerseyDependency()).to(JerseyDependency.class).in(Singleton.class);
+    }
+}


### PR DESCRIPTION
Added handling of all exceptions in LambdaContainerHandler.proxyStream() to return an error rather than a 200.

*Issue #, if available:* #273 

*Description of changes:*
If an exception is thrown that is not explicitly handled by the LambdaContainerHandler.proxyStream() method an empty 200 will be returned. I've only seen this behavior using the Jersey handler but I believe this will also occur in the other handlers. The Jersey handler returns empty 200s if HK2 is unable to resolve dependencies. If the service framework is unable to start I'd expect a 500 to be returned.
