### PR TITLE
Change default shell for execution

### DIFF
--- a/samples/micronaut/pet-store/docker-build.sh
+++ b/samples/micronaut/pet-store/docker-build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 DOCKER_IMAGE_NAME=graalvm-lambda-build
 
 if [[ -d "${PWD}/native-image" ]]; then


### PR DESCRIPTION

*Description of changes:*

It seems, for those who don't have bash as their default shell, [[ is not valid syntax for `sh` (it did not run on my machine running Linux Mint 19 and zsh as my default, I got multiple `./docker-build.sh: 4: ./docker-build.sh: [[: not found` errors). 

I would propose changing this to `#!/bin/bash`, for which this is definitely valid syntax.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
