### PR TITLE
Move afterburner registration to dedicated method

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/LambdaContainerHandler.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/LambdaContainerHandler.java
@@ -81,9 +81,12 @@ public abstract class LambdaContainerHandler<RequestType, ResponseType, Containe
     private static ContainerConfig config = ContainerConfig.defaultConfig();
     private static ObjectMapper objectMapper = new ObjectMapper();
     static {
-        objectMapper.registerModule(new AfterburnerModule());
+        registerAfterBurner();
     }
 
+    private static void registerAfterBurner() {
+        objectMapper.registerModule(new AfterburnerModule());
+    }
 
 
     //-------------------------------------------------------------


### PR DESCRIPTION
*Description of changes:*

This makes it a lot easier for frameworks that want
to use the module in GraalVM, to exclude Afterburner
(which does not work in GraalVM native image because
it generated classes at runtime)

By submitting this pull request

- [ x ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ x ] I confirm that I've made a best effort attempt to update all relevant documentation.