### PR TITLE
fix: ensuring that headers are case insensitive

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -49,11 +49,11 @@ jobs:
         # Spring core 5.2 and above. SpringBoot 1.5 is deprecated
         run: ./gha_build.sh spring true true -Djacoco.minCoverage=0.4
       - name: Build Spring 4.3
-        run: ./gha_build.sh spring false false -Dspring.version=4.3.25.RELEASE -Dspring-security.version=4.2.13.RELEASE
+        run: ./gha_build.sh spring false false -Dspring.version=4.3.29.RELEASE -Dspring-security.version=4.2.18.RELEASE
       - name: Build Spring 5.0
-        run: ./gha_build.sh spring false false -Dspring.version=5.0.16.RELEASE -Dspring-security.version=5.0.14.RELEASE
+        run: ./gha_build.sh spring false false -Dspring.version=5.0.19.RELEASE -Dspring-security.version=5.0.18.RELEASE
       - name: Build Spring 5.1
-        run: ./gha_build.sh spring false false -Dspring.version=5.1.14.RELEASE -Dspring-security.version=5.1.8.RELEASE
+        run: ./gha_build.sh spring false false -Dspring.version=5.1.18.RELEASE -Dspring-security.version=5.1.12.RELEASE
 
   build_springboot2:
     name: Build and test SpringBoot 2
@@ -63,9 +63,9 @@ jobs:
       - name: Build latest
         run: ./gha_build.sh springboot2 true true
       - name: Build Spring Boot 2.0
-        run: ./gha_build.sh springboot2 false false -Dspringboot.version=2.0.9.RELEASE -Dspring.version=5.0.16.RELEASE -Dspringsecurity.version=5.0.14.RELEASE
+        run: ./gha_build.sh springboot2 false false -Dspringboot.version=2.0.9.RELEASE -Dspring.version=5.0.19.RELEASE -Dspringsecurity.version=5.0.18.RELEASE
       - name: Build Spring Boot 2.1
-        run: ./gha_build.sh springboot2 false false -Dspringboot.version=2.1.12.RELEASE -Dspring.version=5.1.13.RELEASE -Dspringsecurity.version=5.1.8.RELEASE
+        run: ./gha_build.sh springboot2 false false -Dspringboot.version=2.1.17.RELEASE -Dspring.version=5.1.18.RELEASE -Dspringsecurity.version=5.1.12.RELEASE
 
   build_struts2:
     name: Build and test Struts 2

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/testutils/AwsProxyRequestBuilder.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/testutils/AwsProxyRequestBuilder.java
@@ -457,7 +457,7 @@ public class AwsProxyRequestBuilder {
         if (request.getMultiValueHeaders() != null && request.getMultiValueHeaders().containsKey(HttpHeaders.COOKIE)) {
             req.setCookies(Arrays.asList(request.getMultiValueHeaders().getFirst(HttpHeaders.COOKIE).split(";")));
         }
-        req.setHeaders(new HashMap<>());
+        req.setHeaders(new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
         if (request.getMultiValueHeaders() != null) {
             request.getMultiValueHeaders().forEach((key, value) -> req.getHeaders().put(key, value.get(0)));
         }

--- a/aws-serverless-java-container-spring/pom.xml
+++ b/aws-serverless-java-container-spring/pom.xml
@@ -16,7 +16,7 @@
     </parent>
 
     <properties>
-        <spring.version>5.2.5.RELEASE</spring.version>
+        <spring.version>5.2.9.RELEASE</spring.version>
         <springboot.version>1.5.22.RELEASE</springboot.version>
         <spring-security.version>5.2.2.RELEASE</spring-security.version>
     </properties>

--- a/aws-serverless-spring-archetype/src/main/resources/archetype-resources/build.gradle
+++ b/aws-serverless-spring-archetype/src/main/resources/archetype-resources/build.gradle
@@ -7,8 +7,8 @@ repositories {
 
 dependencies {
   compile (
-          'org.springframework:spring-webmvc:5.2.5.RELEASE',
-          'org.springframework:spring-context:5.2.5.RELEASE',
+          'org.springframework:spring-webmvc:5.2.9.RELEASE',
+          'org.springframework:spring-context:5.2.9.RELEASE',
           'com.amazonaws.serverless:aws-serverless-java-container-spring:[1.0,)',
           'org.apache.logging.log4j:log4j-core:2.8.2',
           'org.apache.logging.log4j:log4j-api:2.8.2',

--- a/aws-serverless-spring-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/aws-serverless-spring-archetype/src/main/resources/archetype-resources/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <spring.version>5.2.5.RELEASE</spring.version>
+        <spring.version>5.2.9.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <log4j.version>2.8.2</log4j.version>
     </properties>

--- a/samples/spring/pet-store/build.gradle
+++ b/samples/spring/pet-store/build.gradle
@@ -7,8 +7,8 @@ repositories {
 
 dependencies {
   compile (
-          'org.springframework:spring-webmvc:5.2.5.RELEASE',
-          'org.springframework:spring-context:5.2.5.RELEASE',
+          'org.springframework:spring-webmvc:5.2.9.RELEASE',
+          'org.springframework:spring-context:5.2.9.RELEASE',
           'com.amazonaws.serverless:aws-serverless-java-container-spring:[1.0,)',
           'org.apache.logging.log4j:log4j-core:2.8.2',
           'org.apache.logging.log4j:log4j-api:2.8.2',

--- a/samples/spring/pet-store/pom.xml
+++ b/samples/spring/pet-store/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <spring.version>5.2.5.RELEASE</spring.version>
+        <spring.version>5.2.9.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
         <log4j.version>2.13.3</log4j.version>
     </properties>


### PR DESCRIPTION
Currently the header map in HttpApiV2ProxyRequest cannot handle all lower-case headers. I replaced the standard HashMap with a TreeMap using the String.CASE_INSENSITIVE_ORDER comparator to ensure accommodate this.

This is a problem because headers arrive from the API Gateway in all lowercase, but in AwsHttpApiV2SecurityContext, for example, we checking for the capitalised Authorization header.

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.