### PR TITLE
Release 1.5.2

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
@@ -60,7 +60,7 @@ public class AwsProxyHttpServletResponseWriter extends ResponseWriter<AwsHttpSer
             if (!isBinary(containerResponse.getContentType()) && isValidUtf8(containerResponse.getAwsResponseBodyBytes())) {
                 responseString = containerResponse.getAwsResponseBodyString();
             } else {
-                responseString = Base64.getMimeEncoder().encodeToString(containerResponse.getAwsResponseBodyBytes());
+                responseString = Base64.getEncoder().encodeToString(containerResponse.getAwsResponseBodyBytes());
                 awsProxyResponse.setBase64Encoded(true);
             }
 

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
@@ -19,11 +19,14 @@ import com.amazonaws.serverless.proxy.internal.LambdaContainerHandler;
 import com.amazonaws.serverless.proxy.internal.testutils.Timer;
 import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
 import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
+import com.amazonaws.serverless.proxy.model.Headers;
 import com.amazonaws.services.lambda.runtime.Context;
 
 import javax.ws.rs.core.Response;
 
 import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**
@@ -31,6 +34,16 @@ import java.util.Base64;
  * response is not populated with a status code we infer a default 200 status code.
  */
 public class AwsProxyHttpServletResponseWriter extends ResponseWriter<AwsHttpServletResponse, AwsProxyResponse> {
+
+    private boolean writeSingleValueHeaders;
+
+    public AwsProxyHttpServletResponseWriter() {
+        this(false);
+    }
+
+    public AwsProxyHttpServletResponseWriter(boolean singleValueHeaders) {
+        writeSingleValueHeaders = singleValueHeaders;
+    }
 
     //-------------------------------------------------------------
     // Methods - Implementation
@@ -54,6 +67,9 @@ public class AwsProxyHttpServletResponseWriter extends ResponseWriter<AwsHttpSer
             awsProxyResponse.setBody(responseString);
         }
         awsProxyResponse.setMultiValueHeaders(containerResponse.getAwsResponseHeaders());
+        if (writeSingleValueHeaders) {
+            awsProxyResponse.setHeaders(toSingleValueHeaders(containerResponse.getAwsResponseHeaders()));
+        }
 
         awsProxyResponse.setStatusCode(containerResponse.getStatus());
 
@@ -63,6 +79,17 @@ public class AwsProxyHttpServletResponseWriter extends ResponseWriter<AwsHttpSer
 
         Timer.stop("SERVLET_RESPONSE_WRITE");
         return awsProxyResponse;
+    }
+
+    private Map<String, String> toSingleValueHeaders(Headers h) {
+        Map<String, String> out = new HashMap<>();
+        if (h == null || h.isEmpty()) {
+            return out;
+        }
+        for (String k : h.keySet()) {
+            out.put(k, h.getFirst(k));
+        }
+        return out;
     }
 
     private boolean isBinary(String contentType) {

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/ServletLambdaContainerHandlerBuilder.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/ServletLambdaContainerHandlerBuilder.java
@@ -110,7 +110,7 @@ public abstract class ServletLambdaContainerHandlerBuilder<
     public Builder defaultHttpApiV2Proxy() {
         initializationWrapper(new InitializationWrapper())
                 .requestReader((RequestReader<RequestType, ContainerRequestType>) new AwsHttpApiV2HttpServletRequestReader())
-                .responseWriter((ResponseWriter<AwsHttpServletResponse, ResponseType>) new AwsProxyHttpServletResponseWriter())
+                .responseWriter((ResponseWriter<AwsHttpServletResponse, ResponseType>) new AwsProxyHttpServletResponseWriter(true))
                 .securityContextWriter((SecurityContextWriter<RequestType>) new AwsHttpApiV2SecurityContextWriter())
                 .exceptionHandler((ExceptionHandler<ResponseType>) new AwsProxyExceptionHandler())
                 .requestTypeClass((Class<RequestType>) HttpApiV2ProxyRequest.class)

--- a/aws-serverless-java-container-jersey/src/main/java/com/amazonaws/serverless/proxy/jersey/JerseyLambdaContainerHandler.java
+++ b/aws-serverless-java-container-jersey/src/main/java/com/amazonaws/serverless/proxy/jersey/JerseyLambdaContainerHandler.java
@@ -116,7 +116,7 @@ public class JerseyLambdaContainerHandler<RequestType, ResponseType> extends Aws
                 HttpApiV2ProxyRequest.class,
                 AwsProxyResponse.class,
                 new AwsHttpApiV2HttpServletRequestReader(),
-                new AwsProxyHttpServletResponseWriter(),
+                new AwsProxyHttpServletResponseWriter(true),
                 new AwsHttpApiV2SecurityContextWriter(),
                 new AwsProxyExceptionHandler(),
                 jaxRsApplication);

--- a/aws-serverless-java-container-spark/src/main/java/com/amazonaws/serverless/proxy/spark/SparkLambdaContainerHandler.java
+++ b/aws-serverless-java-container-spark/src/main/java/com/amazonaws/serverless/proxy/spark/SparkLambdaContainerHandler.java
@@ -132,7 +132,7 @@ public class SparkLambdaContainerHandler<RequestType, ResponseType>
         SparkLambdaContainerHandler<HttpApiV2ProxyRequest, AwsProxyResponse> newHandler = new SparkLambdaContainerHandler<>(HttpApiV2ProxyRequest.class,
                 AwsProxyResponse.class,
                 new AwsHttpApiV2HttpServletRequestReader(),
-                new AwsProxyHttpServletResponseWriter(),
+                new AwsProxyHttpServletResponseWriter(true),
                 new AwsHttpApiV2SecurityContextWriter(),
                 new AwsProxyExceptionHandler(),
                 new LambdaEmbeddedServerFactory());

--- a/aws-serverless-java-container-springboot2/src/test/java/com/amazonaws/serverless/proxy/spring/ServletAppTest.java
+++ b/aws-serverless-java-container-springboot2/src/test/java/com/amazonaws/serverless/proxy/spring/ServletAppTest.java
@@ -23,8 +23,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
 public class ServletAppTest {
@@ -191,5 +190,19 @@ public class ServletAppTest {
         AwsProxyResponse resp = handler.handleRequest(req, lambdaContext);
         assertNotNull(resp);
         assertEquals(404, resp.getStatusCode());
+    }
+
+    @Test
+    public void echoMessage_populatesSingleValueHeadersForHttpApiV2() {
+        AwsProxyRequestBuilder req = new AwsProxyRequestBuilder("/message", "POST")
+                .header(HttpHeaders.CONTENT_TYPE, "application/json;v=1")
+                .header(HttpHeaders.ACCEPT, "application/json;v=1")
+                .body(new MessageData("test message"));
+        AwsProxyResponse resp = handler.handleRequest(req, lambdaContext);
+        if ("HTTP_API".equals(type)) {
+            assertNotNull(resp.getHeaders());
+        } else {
+            assertNull(resp.getHeaders());
+        }
     }
 }

--- a/aws-serverless-java-container-struts2/src/main/java/com/amazonaws/serverless/proxy/struts2/Struts2LambdaContainerHandler.java
+++ b/aws-serverless-java-container-struts2/src/main/java/com/amazonaws/serverless/proxy/struts2/Struts2LambdaContainerHandler.java
@@ -65,7 +65,7 @@ public class Struts2LambdaContainerHandler<RequestType, ResponseType> extends Aw
                 HttpApiV2ProxyRequest.class,
                 AwsProxyResponse.class,
                 new AwsHttpApiV2HttpServletRequestReader(),
-                new AwsProxyHttpServletResponseWriter(),
+                new AwsProxyHttpServletResponseWriter(true),
                 new AwsHttpApiV2SecurityContextWriter(),
                 new AwsProxyExceptionHandler());
     }


### PR DESCRIPTION
*Issue #, if available:* #339 and #377 

*Description of changes:* Fixes an issue with the binary response content for ALB and bumps Spring 5.2 version to address [Spring's CVE](https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-1009832)


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.