### PR TITLE
Upgrade to latest available Struts GA version 2.5.26

### DIFF
--- a/aws-serverless-java-container-struts2/pom.xml
+++ b/aws-serverless-java-container-struts2/pom.xml
@@ -15,7 +15,7 @@
     </parent>
 
     <properties>
-        <struts2.version>2.5.22</struts2.version>
+        <struts2.version>2.5.26</struts2.version>
     </properties>
 
     <dependencies>

--- a/aws-serverless-java-container-struts2/src/main/java/com/amazonaws/serverless/proxy/struts2/Struts2LambdaHandler.java
+++ b/aws-serverless-java-container-struts2/src/main/java/com/amazonaws/serverless/proxy/struts2/Struts2LambdaHandler.java
@@ -16,8 +16,6 @@ import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
 import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,8 +29,6 @@ import java.io.OutputStream;
  * </code>
  */
 public class Struts2LambdaHandler implements RequestStreamHandler {
-
-    private static final Logger log = LoggerFactory.getLogger(Struts2LambdaHandler.class);
 
     private final Struts2LambdaContainerHandler<AwsProxyRequest, AwsProxyResponse> handler = Struts2LambdaContainerHandler
             .getAwsProxyHandler();

--- a/aws-serverless-struts2-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/aws-serverless-struts2-archetype/src/main/resources/archetype-resources/pom.xml
@@ -15,10 +15,10 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <struts2.version>2.5.22</struts2.version>
-        <jackson.version>2.10.3</jackson.version>
-        <junit.version>4.12</junit.version>
-        <log4j.version>2.8.2</log4j.version>
+        <struts2.version>2.5.26</struts2.version>
+        <jackson.version>2.12.0</jackson.version>
+        <junit.version>4.13.1</junit.version>
+        <log4j.version>2.14.0</log4j.version>
     </properties>
 
     <dependencies>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
 
         <dependency>
@@ -63,14 +63,14 @@
         <dependency>
             <groupId>com.jgeppert.struts2</groupId>
             <artifactId>struts2-aws-lambda-support-plugin</artifactId>
-            <version>1.1.0</version>
+            <version>1.3.0</version>
         </dependency>
 
         <!-- bean validation based on hibernate validators-->
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>4.3.2.Final</version>
+            <version>5.3.6.Final</version>
         </dependency>
 
         <dependency>
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-log4j2</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
* Upgrade to latest available Struts GA version 2.5.26
* Use latest available dependency in Struts2 archetype

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.