### PR TITLE
Allow compilation with JDK version >8 (update jacoco and spotbugs, added activation dependency)

### DIFF
--- a/aws-serverless-java-container-core/pom.xml
+++ b/aws-serverless-java-container-core/pom.xml
@@ -104,7 +104,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.6</version>
                 <configuration>
                     <destFile>${basedir}/target/coverage-reports/jacoco-unit.exec</destFile>
                     <dataFile>${basedir}/target/coverage-reports/jacoco-unit.exec</dataFile>
@@ -151,7 +151,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>4.2.0</version>
                 <configuration>
                     <!--
                         Enables analysis which takes more memory but finds more bugs.
@@ -210,4 +210,19 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>java9-plus</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.sun.activation</groupId>
+                    <artifactId>jakarta.activation</artifactId>
+                    <version>1.2.2</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/filters/UrlPathValidator.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/filters/UrlPathValidator.java
@@ -81,7 +81,7 @@ public class UrlPathValidator implements Filter {
 
         // switching to this mechanism to avoid ReDOS attacks on the path pattern regex
         try {
-            URI uriPath = new URI(path);
+            new URI(path);
         } catch (URISyntaxException e) {
             log.error("Invalid uri path in doFilter", e);
             setErrorResponse(servletResponse);

--- a/aws-serverless-java-container-jersey/pom.xml
+++ b/aws-serverless-java-container-jersey/pom.xml
@@ -107,7 +107,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.6</version>
                 <configuration>
                     <destFile>${basedir}/target/coverage-reports/jacoco-unit.exec</destFile>
                     <dataFile>${basedir}/target/coverage-reports/jacoco-unit.exec</dataFile>
@@ -160,7 +160,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>4.2.0</version>
                 <configuration>
                     <!--
                         Enables analysis which takes more memory but finds more bugs.

--- a/aws-serverless-java-container-spark/pom.xml
+++ b/aws-serverless-java-container-spark/pom.xml
@@ -47,7 +47,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.6</version>
                 <configuration>
                     <destFile>${basedir}/target/coverage-reports/jacoco-unit.exec</destFile>
                     <dataFile>${basedir}/target/coverage-reports/jacoco-unit.exec</dataFile>
@@ -100,7 +100,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>4.2.0</version>
                 <configuration>
                     <!--
                         Enables analysis which takes more memory but finds more bugs.

--- a/aws-serverless-java-container-spring/pom.xml
+++ b/aws-serverless-java-container-spring/pom.xml
@@ -188,7 +188,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.6</version>
                 <configuration>
                     <destFile>${basedir}/target/coverage-reports/jacoco-unit.exec</destFile>
                     <dataFile>${basedir}/target/coverage-reports/jacoco-unit.exec</dataFile>
@@ -241,7 +241,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>4.2.0</version>
                 <configuration>
                     <!--
                         Enables analysis which takes more memory but finds more bugs.

--- a/aws-serverless-java-container-springboot2/pom.xml
+++ b/aws-serverless-java-container-springboot2/pom.xml
@@ -179,7 +179,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.6</version>
                 <configuration>
                     <destFile>${basedir}/target/coverage-reports/jacoco-unit.exec</destFile>
                     <dataFile>${basedir}/target/coverage-reports/jacoco-unit.exec</dataFile>
@@ -234,7 +234,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>4.2.0</version>
                 <configuration>
                     <!--
                         Enables analysis which takes more memory but finds more bugs.

--- a/aws-serverless-java-container-struts2/pom.xml
+++ b/aws-serverless-java-container-struts2/pom.xml
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.1</version>
+                <version>0.8.6</version>
                 <configuration>
                     <destFile>${basedir}/target/coverage-reports/jacoco-unit.exec</destFile>
                     <dataFile>${basedir}/target/coverage-reports/jacoco-unit.exec</dataFile>
@@ -158,7 +158,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>4.2.0</version>
                 <configuration>
                     <!--
                         Enables analysis which takes more memory but finds more bugs.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
update jacoco and spotbugs, added activation dependency

please note the message "Coverage checks have not been met." for certain modules already happened for certain modules and is not related to the change

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.