### PR TITLE
Fixing the cookies field in the v2 request object.

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2ProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2ProxyHttpServletRequest.java
@@ -75,6 +75,13 @@ public class AwsHttpApiV2ProxyHttpServletRequest extends AwsHttpServletRequest {
 
     @Override
     public Cookie[] getCookies() {
+        if (request.getCookies() != null && !request.getCookies().isEmpty()) {
+            return request.getCookies().stream()
+                    .map(cookie -> cookie.split("=", 2))
+                    .map(parts -> new Cookie(SecurityUtils.crlf(parts[0]), SecurityUtils.crlf(parts[1])))
+                    .toArray(Cookie[]::new);
+        }
+
         if (headers == null || !headers.containsKey(HttpHeaders.COOKIE)) {
             return new Cookie[0];
         }

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2HttpServletRequestReaderTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2HttpServletRequestReaderTest.java
@@ -7,6 +7,7 @@ import com.amazonaws.serverless.proxy.model.HttpApiV2ProxyRequest;
 import com.amazonaws.serverless.proxy.model.HttpApiV2ProxyRequestContext;
 import org.junit.Test;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 
 import static org.junit.Assert.*;
@@ -25,6 +26,7 @@ public class AwsHttpApiV2HttpServletRequestReaderTest {
                 .referer("localhost")
                 .queryString("param1", "value1")
                 .header("custom", "value")
+                .cookie("_cookie", "baked")
                 .apiId("test").toHttpApiV2Request();
         AwsHttpApiV2HttpServletRequestReader reader = new AwsHttpApiV2HttpServletRequestReader();
         try {
@@ -32,6 +34,10 @@ public class AwsHttpApiV2HttpServletRequestReaderTest {
             assertEquals("/hello", servletRequest.getPathInfo());
             assertEquals("value1", servletRequest.getParameter("param1"));
             assertEquals("value", servletRequest.getHeader("CUSTOM"));
+            Cookie[] cookies = servletRequest.getCookies();
+            assertEquals(1, cookies.length);
+            assertEquals("_cookie", cookies[0].getName());
+            assertEquals("baked", cookies[0].getValue());
 
             assertNotNull(servletRequest.getAttribute(AwsHttpApiV2HttpServletRequestReader.HTTP_API_CONTEXT_PROPERTY));
             assertEquals("test",


### PR DESCRIPTION
*Issue #, if available:*

The V2 request object would not use the `cookies` field in the `2.0` schema. It would default to an empty array. See https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html for raw input details.

*Description of changes:*

This change first checks of the `cookies` field is set on the underlying request POJO and will use that instead.

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.