### PR TITLE
Revert "Fixing the cookies field in the v2 request object."

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2ProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2ProxyHttpServletRequest.java
@@ -75,13 +75,6 @@ public class AwsHttpApiV2ProxyHttpServletRequest extends AwsHttpServletRequest {
 
     @Override
     public Cookie[] getCookies() {
-        if (request.getCookies() != null && !request.getCookies().isEmpty()) {
-            return request.getCookies().stream()
-                    .map(cookie -> cookie.split("=", 2))
-                    .map(parts -> new Cookie(SecurityUtils.crlf(parts[0]), SecurityUtils.crlf(parts[1])))
-                    .toArray(Cookie[]::new);
-        }
-
         if (headers == null || !headers.containsKey(HttpHeaders.COOKIE)) {
             return new Cookie[0];
         }

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2HttpServletRequestReaderTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2HttpServletRequestReaderTest.java
@@ -7,7 +7,6 @@ import com.amazonaws.serverless.proxy.model.HttpApiV2ProxyRequest;
 import com.amazonaws.serverless.proxy.model.HttpApiV2ProxyRequestContext;
 import org.junit.Test;
 
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 
 import static org.junit.Assert.*;
@@ -26,7 +25,6 @@ public class AwsHttpApiV2HttpServletRequestReaderTest {
                 .referer("localhost")
                 .queryString("param1", "value1")
                 .header("custom", "value")
-                .cookie("_cookie", "baked")
                 .apiId("test").toHttpApiV2Request();
         AwsHttpApiV2HttpServletRequestReader reader = new AwsHttpApiV2HttpServletRequestReader();
         try {
@@ -34,10 +32,6 @@ public class AwsHttpApiV2HttpServletRequestReaderTest {
             assertEquals("/hello", servletRequest.getPathInfo());
             assertEquals("value1", servletRequest.getParameter("param1"));
             assertEquals("value", servletRequest.getHeader("CUSTOM"));
-            Cookie[] cookies = servletRequest.getCookies();
-            assertEquals(1, cookies.length);
-            assertEquals("_cookie", cookies[0].getName());
-            assertEquals("baked", cookies[0].getValue());
 
             assertNotNull(servletRequest.getAttribute(AwsHttpApiV2HttpServletRequestReader.HTTP_API_CONTEXT_PROPERTY));
             assertEquals("test",


### PR DESCRIPTION
Reverts awslabs/aws-serverless-java-container#413 due to test failures
