### PR TITLE
Form param handling fixes

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
@@ -496,14 +496,16 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
         urlEncodedFormParameters = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         for (String parameter : rawBodyContent.split(FORM_DATA_SEPARATOR)) {
             String[] parameterKeyValue = parameter.split(HEADER_KEY_VALUE_SEPARATOR);
-            if (parameterKeyValue.length < 2) {
+            if (parameterKeyValue.length < 1) {
                 continue;
             }
             List<String> values = new ArrayList<>();
             if (urlEncodedFormParameters.containsKey(parameterKeyValue[0])) {
                 values = urlEncodedFormParameters.get(parameterKeyValue[0]);
             }
-            values.add(decodeValueIfEncoded(parameterKeyValue[1]));
+            if (parameterKeyValue.length > 1) {
+                values.add(decodeValueIfEncoded(parameterKeyValue[1]));
+            }
             urlEncodedFormParameters.put(decodeValueIfEncoded(parameterKeyValue[0]), values);
         }
         Timer.stop("SERVLET_REQUEST_GET_FORM_PARAMS");

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
@@ -45,6 +45,9 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 /**
@@ -360,11 +363,12 @@ public class AwsProxyHttpServletRequest extends AwsHttpServletRequest {
 
     @Override
     public Enumeration<String> getParameterNames() {
+        Set<String> formParameterNames = getFormUrlEncodedParametersMap().keySet();
         if (request.getMultiValueQueryStringParameters() == null) {
-            return Collections.emptyEnumeration();
+            return Collections.enumeration(formParameterNames);
         }
-
-        return Collections.enumeration(request.getMultiValueQueryStringParameters().keySet());
+        return Collections.enumeration(Stream.concat(formParameterNames.stream(),
+                request.getMultiValueQueryStringParameters().keySet().stream()).collect(Collectors.toSet()));
     }
 
 

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestFormTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestFormTest.java
@@ -18,6 +18,7 @@ import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Random;
 
@@ -123,6 +124,7 @@ public class AwsProxyHttpServletRequestFormTest {
         assertNotNull(params);
         assertEquals(2, params.size());
         assertTrue(params.containsKey(PART_KEY_1));
+        assertEquals(2, Collections.list(request.getParameterNames()).size());
     }
 
     /**
@@ -140,5 +142,6 @@ public class AwsProxyHttpServletRequestFormTest {
         assertNotNull(params);
         assertEquals(2, params.size());
         assertTrue(params.containsKey(PART_KEY_1));
+        assertEquals(2, Collections.list(request.getParameterNames()).size());
     }
 }

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestFormTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestFormTest.java
@@ -23,6 +23,7 @@ import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 
@@ -121,7 +122,7 @@ public class AwsProxyHttpServletRequestFormTest {
         Map<String, String[]> params = request.getParameterMap();
         assertNotNull(params);
         assertEquals(2, params.size());
-        assertEquals(true, params.containsKey(PART_KEY_1));
+        assertTrue(params.containsKey(PART_KEY_1));
     }
 
     /**
@@ -138,6 +139,6 @@ public class AwsProxyHttpServletRequestFormTest {
         Map<String, String[]> params = request.getParameterMap();
         assertNotNull(params);
         assertEquals(2, params.size());
-        assertEquals(true, params.containsKey(PART_KEY_1));
+        assertTrue(params.containsKey(PART_KEY_1));
     }
 }

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestFormTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestFormTest.java
@@ -123,4 +123,21 @@ public class AwsProxyHttpServletRequestFormTest {
         assertEquals(2, params.size());
         assertEquals(true, params.containsKey(PART_KEY_1));
     }
+
+    /**
+     * issue #340
+     */
+    @Test
+    public void postForm_emptyParamPresent() {
+        AwsProxyRequest proxyRequest = new AwsProxyRequestBuilder("/form", "POST")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED).build();
+        String body = PART_KEY_1 + "=" + "&" + PART_KEY_2 + "=" + PART_VALUE_2;
+        proxyRequest.setBody(body);
+
+        HttpServletRequest request = new AwsProxyHttpServletRequest(proxyRequest, null, null);
+        Map<String, String[]> params = request.getParameterMap();
+        assertNotNull(params);
+        assertEquals(2, params.size());
+        assertEquals(true, params.containsKey(PART_KEY_1));
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
#340 

*Description of changes:*

* Empty form params are now available as part of the request object.
* Form param names are now included in getParameterNames()

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.