### PR TITLE
Could com.amazonaws.serverless.sample:serverless-jersey-example:1.0-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/samples/jersey/pet-store/pom.xml
+++ b/samples/jersey/pet-store/pom.xml
@@ -35,6 +35,32 @@
             <groupId>com.amazonaws.serverless</groupId>
             <artifactId>aws-serverless-java-container-jersey</artifactId>
             <version>[1.6,)</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.validation</groupId>
+                    <artifactId>jakarta.validation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.ws.rs</groupId>
+                    <artifactId>jakarta.ws.rs-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.annotation</groupId>
+                    <artifactId>jakarta.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>javax.ws.rs-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>jakarta.inject</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -60,6 +86,22 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jakarta.activation</groupId>
+                    <artifactId>jakarta.activation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.annotation</groupId>
+                    <artifactId>jakarta.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>jakarta.inject</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -71,6 +113,10 @@
                 <exclusion>
                     <groupId>javax.inject</groupId>
                     <artifactId>javax.inject</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>jakarta.inject</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Hi! I found the pom file of project **_com.amazonaws.serverless.sample:serverless-jersey-example:1.0-SNAPSHOT_** introduced **_41_** dependencies. However, among them, **_7_** libraries (**_17%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
javax.servlet:javax.servlet-api:jar:3.1.0:compile
javax.ws.rs:javax.ws.rs-api:jar:2.1:compile
jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile
org.glassfish.hk2.external:jakarta.inject:jar:2.6.1:compile
jakarta.validation:jakarta.validation-api:jar:2.0.2:compile
jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.2:compile
jakarta.activation:jakarta.activation-api:jar:1.2.1:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile_** incorporates an incompatible license EPL 2.0 (EPL 2.0 cannot be used by the project with license The Apache Software License, Version 2.0), one of the redundant dependencies **_org.glassfish.hk2.external:jakarta.inject:jar:2.6.1:compile_** incorporates an incompatible license EPL 2.0 (EPL 2.0 cannot be used by the project with license The Apache Software License, Version 2.0). 2 of the redundant dependencies **_jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile, org.glassfish.hk2.external:jakarta.inject:jar:2.6.1:compile_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_com.amazonaws.serverless.sample:serverless-jersey-example:1.0-SNAPSHOT_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_com.amazonaws.serverless.sample:serverless-jersey-example:1.0-SNAPSHOT_**’s maven tests.

Best regards
![image](https://user-images.githubusercontent.com/78527112/160520723-f2dae2b5-d184-45a0-8784-7c15380cc511.png)
