### PR TITLE
Add support for HTTP API cookie parameter

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2ProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2ProxyHttpServletRequest.java
@@ -37,6 +37,7 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.*;
+import java.util.stream.Stream;
 
 public class AwsHttpApiV2ProxyHttpServletRequest extends AwsHttpServletRequest {
     private static Logger log = LoggerFactory.getLogger(AwsHttpApiV2ProxyHttpServletRequest.class);
@@ -75,11 +76,33 @@ public class AwsHttpApiV2ProxyHttpServletRequest extends AwsHttpServletRequest {
 
     @Override
     public Cookie[] getCookies() {
+        Cookie[] rhc;
         if (headers == null || !headers.containsKey(HttpHeaders.COOKIE)) {
-            return new Cookie[0];
+            rhc = new Cookie[0];
+        } else {
+            rhc = parseCookieHeaderValue(headers.getFirst(HttpHeaders.COOKIE));
         }
 
-        return parseCookieHeaderValue(headers.getFirst(HttpHeaders.COOKIE));
+        Cookie[] rc;
+        if (request.getCookies() == null) {
+            rc = new Cookie[0];
+        } else {
+            rc = request.getCookies().stream()
+                .map(c -> {
+                    int i = c.indexOf('=');
+                    if (i == -1) {
+                        return null;
+                    } else {
+                        String k = SecurityUtils.crlf(c.substring(0, i)).trim();
+                        String v = SecurityUtils.crlf(c.substring(i+1));
+                        return new Cookie(k, v);
+                    }
+                })
+                .filter(c -> c != null)
+                .toArray(Cookie[]::new);
+        }
+
+        return Stream.concat(Arrays.stream(rhc), Arrays.stream(rc)).toArray(Cookie[]::new);
     }
 
     @Override

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/testutils/AwsProxyRequestBuilder.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/testutils/AwsProxyRequestBuilder.java
@@ -459,7 +459,11 @@ public class AwsProxyRequestBuilder {
         }
         req.setHeaders(new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
         if (request.getMultiValueHeaders() != null) {
-            request.getMultiValueHeaders().forEach((key, value) -> req.getHeaders().put(key, value.get(0)));
+            request.getMultiValueHeaders().forEach((key, value) -> {
+                if (!HttpHeaders.COOKIE.equals(key)) {
+                    req.getHeaders().put(key, value.get(0));
+                }
+            });
         }
         if (request.getRequestContext() != null && request.getRequestContext().getIdentity() != null) {
             if (request.getRequestContext().getIdentity().getCaller() != null) {

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2HttpServletRequestReaderTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2HttpServletRequestReaderTest.java
@@ -25,6 +25,7 @@ public class AwsHttpApiV2HttpServletRequestReaderTest {
                 .referer("localhost")
                 .queryString("param1", "value1")
                 .header("custom", "value")
+                .cookie("cookey", "cooval")
                 .apiId("test").toHttpApiV2Request();
         AwsHttpApiV2HttpServletRequestReader reader = new AwsHttpApiV2HttpServletRequestReader();
         try {
@@ -32,6 +33,11 @@ public class AwsHttpApiV2HttpServletRequestReaderTest {
             assertEquals("/hello", servletRequest.getPathInfo());
             assertEquals("value1", servletRequest.getParameter("param1"));
             assertEquals("value", servletRequest.getHeader("CUSTOM"));
+
+            assertNotNull(servletRequest.getCookies());
+            assertEquals(1, servletRequest.getCookies().length);
+            assertEquals("cookey", servletRequest.getCookies()[0].getName());
+            assertEquals("cooval", servletRequest.getCookies()[0].getValue());
 
             assertNotNull(servletRequest.getAttribute(AwsHttpApiV2HttpServletRequestReader.HTTP_API_CONTEXT_PROPERTY));
             assertEquals("test",


### PR DESCRIPTION
*Issue #452*

*Description of changes:*

For request v2 (HTTP APIs), read cookies from the dedicated section in addition to headers. HTTP APIs also filter cookies with no names.

Unsure if HTTP API will never send cookie in header; if so, we can remove the header parse section.

*Testing:*
`mvn test`

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.