### PR TITLE
fix: AwsHttpApiV2ProxyHttpServletRequest.headersMapToMultiValue trunc…

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2ProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2ProxyHttpServletRequest.java
@@ -533,6 +533,7 @@ public class AwsHttpApiV2ProxyHttpServletRequest extends AwsHttpServletRequest {
             // Exceptions for known header values that contain commas
             if (hkv.getKey().equalsIgnoreCase(HttpHeaders.DATE) ||
                             hkv.getKey().equalsIgnoreCase(HttpHeaders.IF_MODIFIED_SINCE) ||
+                            hkv.getKey().equalsIgnoreCase(HttpHeaders.USER_AGENT) ||
                             hkv.getKey().toLowerCase(Locale.getDefault()).startsWith("accept-")) {
                 h.add(hkv.getKey(), hkv.getValue());
                 continue;

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2HttpServletRequestReaderTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2HttpServletRequestReaderTest.java
@@ -8,6 +8,7 @@ import com.amazonaws.serverless.proxy.model.HttpApiV2ProxyRequestContext;
 import org.junit.Test;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.HttpHeaders;
 
 import static org.junit.Assert.*;
 
@@ -23,6 +24,7 @@ public class AwsHttpApiV2HttpServletRequestReaderTest {
     public void baseRequest_read_populatesSuccessfully() {
         HttpApiV2ProxyRequest req = new AwsProxyRequestBuilder("/hello", "GET")
                 .referer("localhost")
+                .userAgent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.61 Safari/537.36")
                 .queryString("param1", "value1")
                 .header("custom", "value")
                 .cookie("cookey", "cooval")
@@ -33,6 +35,7 @@ public class AwsHttpApiV2HttpServletRequestReaderTest {
             assertEquals("/hello", servletRequest.getPathInfo());
             assertEquals("value1", servletRequest.getParameter("param1"));
             assertEquals("value", servletRequest.getHeader("CUSTOM"));
+            assertEquals("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.61 Safari/537.36", servletRequest.getHeader(HttpHeaders.USER_AGENT));
 
             assertNotNull(servletRequest.getCookies());
             assertEquals(1, servletRequest.getCookies().length);

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestTest.java
@@ -36,7 +36,7 @@ public class AwsProxyHttpServletRequestTest {
     private static final String FORM_PARAM_TEST = "test_cookie_param";
     private static final String QUERY_STRING_NAME_VALUE = "Bob";
     private static final String REQUEST_SCHEME_HTTP = "http";
-    private static final String USER_AGENT = "Mozilla/5.0 (Android 4.4; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0";
+    private static final String USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.61 Safari/537.36";
     private static final String REFERER = "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent/Firefox";
     private static ZonedDateTime REQUEST_DATE = ZonedDateTime.now();
 


### PR DESCRIPTION
fix: AwsHttpApiV2ProxyHttpServletRequest.headersMapToMultiValue truncates the user-agent (#464)

*Issue:* #464

*Description of changes:*
User-agent is now handled as a single value header that can contains commas.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.