### PR TITLE
Handle AwsProxyRequest with single-valued collections only

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/serialization/AwsProxyRequestConverter.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/serialization/AwsProxyRequestConverter.java
@@ -17,38 +17,46 @@ import com.fasterxml.jackson.databind.util.Converter;
 public class AwsProxyRequestConverter implements Converter < AwsProxyRequest, AwsProxyRequest > {
   @Override
   public AwsProxyRequest convert(AwsProxyRequest value) {
-      if (value == null)
-          return null;
+        if (value == null)
+            return null;
 
-      if ((value.getMultiValueHeaders() == null || value.getMultiValueHeaders().isEmpty()) &&
-          value.getHeaders() != null && !value.getHeaders().isEmpty()) {
-          Headers multiValueHeaders = new Headers();
-          for (Map.Entry < String, String > e: value.getHeaders().entrySet())
-              multiValueHeaders.putSingle(e.getKey(), e.getValue());
-          value.setMultiValueHeaders(multiValueHeaders);
-      }
+        if ((value.getMultiValueHeaders() == null || value.getMultiValueHeaders().isEmpty()) &&
+                value.getHeaders() != null && !value.getHeaders().isEmpty()) {
+            copySingleValueHeadersToMultiValueHeaders(value);
+        }
 
-      if ((value.getMultiValueQueryStringParameters() == null ||
-              value.getMultiValueQueryStringParameters().isEmpty()) &&
-          value.getQueryStringParameters() != null &&
-          !value.getQueryStringParameters().isEmpty()) {
-          MultiValuedTreeMap < String, String > multiValueQueryStringParameters =
-              new MultiValuedTreeMap < > ();
-          for (Map.Entry < String, String > e: value.getQueryStringParameters().entrySet())
-              multiValueQueryStringParameters.putSingle(e.getKey(), e.getValue());
-          value.setMultiValueQueryStringParameters(multiValueQueryStringParameters);
-      }
+        if ((value.getMultiValueQueryStringParameters() == null ||
+                value.getMultiValueQueryStringParameters().isEmpty()) &&
+                value.getQueryStringParameters() != null &&
+                !value.getQueryStringParameters().isEmpty()) {
+            copySingleValueQueryStringParametersToMultiValueQueryStringParameters(value);
+        }
 
-      return value;
-  }
+        return value;
+    }
 
-  @Override
-  public JavaType getInputType(TypeFactory typeFactory) {
-      return typeFactory.constructType(AwsProxyRequest.class);
-  }
+    private void copySingleValueHeadersToMultiValueHeaders(AwsProxyRequest value) {
+        Headers multiValueHeaders = new Headers();
+        for (Map.Entry < String, String > e: value.getHeaders().entrySet())
+            multiValueHeaders.putSingle(e.getKey(), e.getValue());
+        value.setMultiValueHeaders(multiValueHeaders);
+    }
 
-  @Override
-  public JavaType getOutputType(TypeFactory typeFactory) {
-      return typeFactory.constructType(AwsProxyRequest.class);
-  }
+    private void copySingleValueQueryStringParametersToMultiValueQueryStringParameters(AwsProxyRequest value) {
+        MultiValuedTreeMap < String, String > multiValueQueryStringParameters =
+            new MultiValuedTreeMap < > ();
+        for (Map.Entry < String, String > e: value.getQueryStringParameters().entrySet())
+            multiValueQueryStringParameters.putSingle(e.getKey(), e.getValue());
+        value.setMultiValueQueryStringParameters(multiValueQueryStringParameters);
+    }
+
+    @Override
+    public JavaType getInputType(TypeFactory typeFactory) {
+        return typeFactory.constructType(AwsProxyRequest.class);
+    }
+
+    @Override
+    public JavaType getOutputType(TypeFactory typeFactory) {
+        return typeFactory.constructType(AwsProxyRequest.class);
+    }
 }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/serialization/AwsProxyRequestConverter.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/serialization/AwsProxyRequestConverter.java
@@ -1,0 +1,48 @@
+package com.amazonaws.serverless.proxy.internal.serialization;
+
+import java.util.Map;
+import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
+import com.amazonaws.serverless.proxy.model.Headers;
+import com.amazonaws.serverless.proxy.model.MultiValuedTreeMap;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.databind.util.Converter;
+
+public class AwsProxyRequestConverter implements Converter<AwsProxyRequest, AwsProxyRequest> {
+  @Override
+  public AwsProxyRequest convert(AwsProxyRequest value) {
+    if (value == null)
+      return null;
+
+    if ((value.getMultiValueHeaders() == null || value.getMultiValueHeaders().isEmpty())
+        && value.getHeaders() != null && !value.getHeaders().isEmpty()) {
+      Headers multiValueHeaders = new Headers();
+      for (Map.Entry<String, String> e : value.getHeaders().entrySet())
+        multiValueHeaders.putSingle(e.getKey(), e.getValue());
+      value.setMultiValueHeaders(multiValueHeaders);
+    }
+
+    if ((value.getMultiValueQueryStringParameters() == null
+        || value.getMultiValueQueryStringParameters().isEmpty())
+        && value.getQueryStringParameters() != null
+        && !value.getQueryStringParameters().isEmpty()) {
+      MultiValuedTreeMap<String, String> multiValueQueryStringParameters =
+          new MultiValuedTreeMap<>();
+      for (Map.Entry<String, String> e : value.getQueryStringParameters().entrySet())
+        multiValueQueryStringParameters.putSingle(e.getKey(), e.getValue());
+      value.setMultiValueQueryStringParameters(multiValueQueryStringParameters);
+    }
+    
+    return value;
+  }
+
+  @Override
+  public JavaType getInputType(TypeFactory typeFactory) {
+    return typeFactory.constructType(AwsProxyRequest.class);
+  }
+
+  @Override
+  public JavaType getOutputType(TypeFactory typeFactory) {
+    return typeFactory.constructType(AwsProxyRequest.class);
+  }
+}

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/serialization/AwsProxyRequestConverter.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/serialization/AwsProxyRequestConverter.java
@@ -8,41 +8,47 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.databind.util.Converter;
 
-public class AwsProxyRequestConverter implements Converter<AwsProxyRequest, AwsProxyRequest> {
+/**
+ * Populates multi-valued collections from single-valued collections if the former are not given
+ * or are empty and the latter are present and populated. This is a real-life scenario when
+ * an ALB targets a Lambda function and `lambda.multi_value_headers.enabled` is not set to `true`
+ * on the target group. 
+ */
+public class AwsProxyRequestConverter implements Converter < AwsProxyRequest, AwsProxyRequest > {
   @Override
   public AwsProxyRequest convert(AwsProxyRequest value) {
-    if (value == null)
-      return null;
+      if (value == null)
+          return null;
 
-    if ((value.getMultiValueHeaders() == null || value.getMultiValueHeaders().isEmpty())
-        && value.getHeaders() != null && !value.getHeaders().isEmpty()) {
-      Headers multiValueHeaders = new Headers();
-      for (Map.Entry<String, String> e : value.getHeaders().entrySet())
-        multiValueHeaders.putSingle(e.getKey(), e.getValue());
-      value.setMultiValueHeaders(multiValueHeaders);
-    }
+      if ((value.getMultiValueHeaders() == null || value.getMultiValueHeaders().isEmpty()) &&
+          value.getHeaders() != null && !value.getHeaders().isEmpty()) {
+          Headers multiValueHeaders = new Headers();
+          for (Map.Entry < String, String > e: value.getHeaders().entrySet())
+              multiValueHeaders.putSingle(e.getKey(), e.getValue());
+          value.setMultiValueHeaders(multiValueHeaders);
+      }
 
-    if ((value.getMultiValueQueryStringParameters() == null
-        || value.getMultiValueQueryStringParameters().isEmpty())
-        && value.getQueryStringParameters() != null
-        && !value.getQueryStringParameters().isEmpty()) {
-      MultiValuedTreeMap<String, String> multiValueQueryStringParameters =
-          new MultiValuedTreeMap<>();
-      for (Map.Entry<String, String> e : value.getQueryStringParameters().entrySet())
-        multiValueQueryStringParameters.putSingle(e.getKey(), e.getValue());
-      value.setMultiValueQueryStringParameters(multiValueQueryStringParameters);
-    }
-    
-    return value;
+      if ((value.getMultiValueQueryStringParameters() == null ||
+              value.getMultiValueQueryStringParameters().isEmpty()) &&
+          value.getQueryStringParameters() != null &&
+          !value.getQueryStringParameters().isEmpty()) {
+          MultiValuedTreeMap < String, String > multiValueQueryStringParameters =
+              new MultiValuedTreeMap < > ();
+          for (Map.Entry < String, String > e: value.getQueryStringParameters().entrySet())
+              multiValueQueryStringParameters.putSingle(e.getKey(), e.getValue());
+          value.setMultiValueQueryStringParameters(multiValueQueryStringParameters);
+      }
+
+      return value;
   }
 
   @Override
   public JavaType getInputType(TypeFactory typeFactory) {
-    return typeFactory.constructType(AwsProxyRequest.class);
+      return typeFactory.constructType(AwsProxyRequest.class);
   }
 
   @Override
   public JavaType getOutputType(TypeFactory typeFactory) {
-    return typeFactory.constructType(AwsProxyRequest.class);
+      return typeFactory.constructType(AwsProxyRequest.class);
   }
 }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/model/AwsProxyRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/model/AwsProxyRequest.java
@@ -14,14 +14,17 @@ package com.amazonaws.serverless.proxy.model;
 
 import java.util.HashMap;
 import java.util.Map;
+import com.amazonaws.serverless.proxy.internal.serialization.AwsProxyRequestConverter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Default implementation of the request object from an API Gateway AWS_PROXY integration
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonDeserialize(converter=AwsProxyRequestConverter.class)
 public class AwsProxyRequest {
 
     //-------------------------------------------------------------
@@ -32,7 +35,7 @@ public class AwsProxyRequest {
     private String resource;
     private AwsProxyRequestContext requestContext;
     private MultiValuedTreeMap<String, String> multiValueQueryStringParameters;
-    private Map<String, String> queryStringParameters; 
+    private Map<String, String> queryStringParameters;
     private Headers multiValueHeaders;
     private SingleValueHeaders headers;
     private Map<String, String> pathParameters;

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/model/AwsProxyRequestTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/model/AwsProxyRequestTest.java
@@ -105,16 +105,22 @@ public class AwsProxyRequestTest {
                 "}";
     }
 
+    /**
+     * Receiving a request with single-valued headers only should get mapped to multi-valued
+     * headers by the custom converter from the AwsProxyRequest class @JsonDeserialize annotation.
+     * @throws IOException
+     */
     @Test
     public void deserialize_singleValuedHeaders() throws IOException {
         AwsProxyRequest req =
             new AwsProxyRequestBuilder().fromJsonString(getSingleValueRequestJson()).build();
 
         assertThat(req.getHeaders().get("accept"), is("*"));
+        assertThat(req.getMultiValueHeaders().getFirst("accept"), is("*"));
     }
 
     /**
-     * Captured from a live request to an ALB with a Lambda integration with 
+     * Captured from a live request to an ALB with a Lambda integration with
      * lambda.multi_value_headers.enabled=false.
      */
     private String getSingleValueRequestJson() {


### PR DESCRIPTION
This PR improves handling of some web requests, particularly ALB requests to Lambda endpoints.

https://github.com/awslabs/aws-serverless-java-container/issues/315

This change adds a custom [Jackson Converter](https://fasterxml.github.io/jackson-databind/javadoc/2.5/com/fasterxml/jackson/databind/util/Converter.html) to populate `AwsProxyRequest` multi-valued collections (i.e., `multiValueQueryStringParameters`, `multiValueHeaders`) from single-valued collections (i.e., `queryStringParameters`, `headers`) if the former are not present and populated but the latter are. This is based off a real-life scenario where an ALB targets a Lambda function and `lambda.multi_value_headers.enabled` is not set to `true` on the target group.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.