### PR TITLE
Fixing NullpointerException in case of non defined statusCode

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
@@ -20,6 +20,7 @@ import com.amazonaws.serverless.proxy.internal.testutils.Timer;
 import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
 import com.amazonaws.serverless.proxy.model.Headers;
 import com.amazonaws.serverless.proxy.model.RequestSource;
+import com.amazonaws.serverless.proxy.model.RequestSource;
 import com.amazonaws.services.lambda.runtime.Context;
 
 import javax.ws.rs.core.Response;

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
@@ -23,11 +23,11 @@ import com.amazonaws.serverless.proxy.model.RequestSource;
 import com.amazonaws.services.lambda.runtime.Context;
 
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
-import javax.ws.rs.core.Response.Status;
 
 
 /**
@@ -76,7 +76,8 @@ public class AwsProxyHttpServletResponseWriter extends ResponseWriter<AwsHttpSer
 
         Status responseStatus = Response.Status.fromStatusCode(containerResponse.getStatus());
 
-        if (containerResponse.getAwsProxyRequest() != null && containerResponse.getAwsProxyRequest().getRequestSource() == RequestSource.ALB && responseStatus != null) {
+        if (containerResponse.getAwsProxyRequest() != null && containerResponse.getAwsProxyRequest().getRequestSource() == RequestSource.ALB
+                && responseStatus != null) {
             awsProxyResponse.setStatusDescription(containerResponse.getStatus() + " " + responseStatus.getReasonPhrase());
         }
 

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
@@ -27,6 +27,7 @@ import javax.ws.rs.core.Response;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
+import javax.ws.rs.core.Response.Status;
 
 
 /**

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
@@ -17,7 +17,6 @@ import com.amazonaws.serverless.exceptions.InvalidResponseObjectException;
 import com.amazonaws.serverless.proxy.ResponseWriter;
 import com.amazonaws.serverless.proxy.internal.LambdaContainerHandler;
 import com.amazonaws.serverless.proxy.internal.testutils.Timer;
-import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
 import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
 import com.amazonaws.serverless.proxy.model.Headers;
 import com.amazonaws.serverless.proxy.model.RequestSource;
@@ -75,7 +74,11 @@ public class AwsProxyHttpServletResponseWriter extends ResponseWriter<AwsHttpSer
         awsProxyResponse.setStatusCode(containerResponse.getStatus());
 
         if (containerResponse.getAwsProxyRequest() != null && containerResponse.getAwsProxyRequest().getRequestSource() == RequestSource.ALB) {
-            awsProxyResponse.setStatusDescription(containerResponse.getStatus() + " " + Response.Status.fromStatusCode(containerResponse.getStatus()).getReasonPhrase());
+            if (Response.Status.fromStatusCode(containerResponse.getStatus()) != null) {
+                awsProxyResponse.setStatusDescription(containerResponse.getStatus() + " " + Response.Status.fromStatusCode(containerResponse.getStatus()).getReasonPhrase());
+            } else {
+                awsProxyResponse.setStatusDescription(containerResponse.getStatus());
+            }
         }
 
         Timer.stop("SERVLET_RESPONSE_WRITE");

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
@@ -77,7 +77,7 @@ public class AwsProxyHttpServletResponseWriter extends ResponseWriter<AwsHttpSer
             if (Response.Status.fromStatusCode(containerResponse.getStatus()) != null) {
                 awsProxyResponse.setStatusDescription(containerResponse.getStatus() + " " + Response.Status.fromStatusCode(containerResponse.getStatus()).getReasonPhrase());
             } else {
-                awsProxyResponse.setStatusDescription(containerResponse.getStatus());
+                awsProxyResponse.setStatusDescription(String.valueOf(containerResponse.getStatus()));
             }
         }
 

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletResponseWriter.java
@@ -20,7 +20,6 @@ import com.amazonaws.serverless.proxy.internal.testutils.Timer;
 import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
 import com.amazonaws.serverless.proxy.model.Headers;
 import com.amazonaws.serverless.proxy.model.RequestSource;
-import com.amazonaws.serverless.proxy.model.RequestSource;
 import com.amazonaws.services.lambda.runtime.Context;
 
 import javax.ws.rs.core.Response;
@@ -74,12 +73,10 @@ public class AwsProxyHttpServletResponseWriter extends ResponseWriter<AwsHttpSer
 
         awsProxyResponse.setStatusCode(containerResponse.getStatus());
 
-        if (containerResponse.getAwsProxyRequest() != null && containerResponse.getAwsProxyRequest().getRequestSource() == RequestSource.ALB) {
-            if (Response.Status.fromStatusCode(containerResponse.getStatus()) != null) {
-                awsProxyResponse.setStatusDescription(containerResponse.getStatus() + " " + Response.Status.fromStatusCode(containerResponse.getStatus()).getReasonPhrase());
-            } else {
-                awsProxyResponse.setStatusDescription(String.valueOf(containerResponse.getStatus()));
-            }
+        Status responseStatus = Response.Status.fromStatusCode(containerResponse.getStatus());
+
+        if (containerResponse.getAwsProxyRequest() != null && containerResponse.getAwsProxyRequest().getRequestSource() == RequestSource.ALB && responseStatus != null) {
+            awsProxyResponse.setStatusDescription(containerResponse.getStatus() + " " + responseStatus.getReasonPhrase());
         }
 
         Timer.stop("SERVLET_RESPONSE_WRITE");


### PR DESCRIPTION
Fix provided for: https://github.com/awslabs/aws-serverless-java-container/issues/497

This is to resolve NullPointerException when HttpStatusCode is not present in default enum Response.StatusType

*Issue #, https://github.com/awslabs/aws-serverless-java-container/issues/497

*Description of changes:*


By submitting this pull request

- [/] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ /] I confirm that I've made a best effort attempt to update all relevant documentation.