### PR TITLE
fix: Write resources using the charset defined in a Content-Type header

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletResponse.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletResponse.java
@@ -213,7 +213,7 @@ public class AwsHttpServletResponse
     @Override
     public void setHeader(String s, String s1) {
         if (!canSetHeader()) return;
-        if ("Content-Type".equalsIgnoreCase(s)) {
+        if (isContentTypeHeader(s)) {
             setContentType(s1);
         } else {
             setHeader(s, s1, true);
@@ -221,11 +221,16 @@ public class AwsHttpServletResponse
     }
 
 
+    private boolean isContentTypeHeader(String s) {
+        return s.toLowerCase(Locale.getDefault()).equals(HttpHeaders.CONTENT_TYPE.toLowerCase(Locale.getDefault()));
+    }
+
+
     @Override
     public void addHeader(String s, String s1) {
         if (!canSetHeader()) return;
         // TODO: We should probably have a list of headers that we are not allowed to have multiple values for
-        if (s.toLowerCase(Locale.getDefault()).equals(HttpHeaders.CONTENT_TYPE.toLowerCase(Locale.getDefault()))) {
+        if (isContentTypeHeader(s)) {
             setContentType(s1);
         } else {
             setHeader(s, s1, false);

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletResponse.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletResponse.java
@@ -213,7 +213,11 @@ public class AwsHttpServletResponse
     @Override
     public void setHeader(String s, String s1) {
         if (!canSetHeader()) return;
-        setHeader(s, s1, true);
+        if ("Content-Type".equalsIgnoreCase(s)) {
+            setContentType(s1);
+        } else {
+            setHeader(s, s1, true);
+        }
     }
 
 

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletResponseTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletResponseTest.java
@@ -12,6 +12,7 @@ import javax.ws.rs.core.MediaType;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -38,6 +39,7 @@ public class AwsHttpServletResponseTest {
     private static final Pattern EXPIRES_PATTERN = Pattern.compile("Expires=(.*)$");
 
     private static final String CONTENT_TYPE_WITH_CHARSET = "application/json; charset=UTF-8";
+    private static final String JAVASCRIPT_CONTENT_TYPE_WITH_CHARSET = "application/javascript; charset=UTF-8";
 
     @Test
     void cookie_addCookie_verifyPath() {
@@ -323,6 +325,18 @@ public class AwsHttpServletResponseTest {
         assertEquals(CONTENT_TYPE_WITH_CHARSET, resp.getContentType());
         assertEquals(CONTENT_TYPE_WITH_CHARSET, resp.getHeader("Content-Type"));
         assertEquals("UTF-8", resp.getCharacterEncoding());
+    }
+
+    @Test
+    void characterEncoding_encodingInContentTypeHeader_writesCorrectData() throws IOException {
+        AwsHttpServletResponse resp = new AwsHttpServletResponse(null, new CountDownLatch(1));
+        resp.setHeader("Content-Type", JAVASCRIPT_CONTENT_TYPE_WITH_CHARSET);
+        resp.getOutputStream().write("ü".getBytes(StandardCharsets.UTF_8));
+        resp.flushBuffer();
+
+        assertEquals(JAVASCRIPT_CONTENT_TYPE_WITH_CHARSET, resp.getContentType());
+        assertEquals(JAVASCRIPT_CONTENT_TYPE_WITH_CHARSET, resp.getHeader("Content-Type"));
+        assertEquals("ü",resp.getAwsResponseBodyString());
     }
 
     private int getMaxAge(String header) {


### PR DESCRIPTION
*Description of changes:*

Setting the content type through a header should be equal to setting the content type using `setContentType`. In both cases the defined character set must be used for writing the result.


By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.