### PR TITLE
fix: Dispatch to the given servlet when using getNamedDispatcher

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyRequestDispatcher.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyRequestDispatcher.java
@@ -80,7 +80,7 @@ public class AwsProxyRequestDispatcher implements RequestDispatcher {
         }
 
         if (isNamedDispatcher) {
-            lambdaContainerHandler.doFilter((HttpServletRequest) servletRequest, (HttpServletResponse) servletResponse, getServlet((HttpServletRequest)servletRequest));
+            lambdaContainerHandler.doFilter((HttpServletRequest) servletRequest, (HttpServletResponse) servletResponse, getServlet(dispatchTo));
             return;
         }
 
@@ -148,4 +148,9 @@ public class AwsProxyRequestDispatcher implements RequestDispatcher {
     private Servlet getServlet(HttpServletRequest req) {
         return ((AwsServletContext)lambdaContainerHandler.getServletContext()).getServletForPath(req.getPathInfo());
     }
+
+    private Servlet getServlet(String servletName) throws ServletException {
+        return ((AwsServletContext)lambdaContainerHandler.getServletContext()).getServlet(servletName);
+    }
+
 }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContext.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContext.java
@@ -171,7 +171,7 @@ public class AwsServletContext
 
     @Override
     public RequestDispatcher getNamedDispatcher(String s) {
-        throw new UnsupportedOperationException();
+        return new AwsProxyRequestDispatcher(s, true, containerHandler);
     }
 
 

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/testutils/MockServlet.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/testutils/MockServlet.java
@@ -1,0 +1,23 @@
+package com.amazonaws.serverless.proxy.internal.testutils;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class MockServlet extends HttpServlet {
+
+    private int serviceCalls = 0;
+
+    @Override
+    protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        super.service(req, resp);
+        serviceCalls++;
+    }
+
+    public int getServiceCalls() {
+        return serviceCalls;
+    }
+}

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContextTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContextTest.java
@@ -13,12 +13,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.concurrent.CountDownLatch;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -190,12 +185,7 @@ public class AwsServletContextTest {
         } catch (UnsupportedOperationException e) {
             exCount++;
         }
-        try {
-            STATIC_CTX.getNamedDispatcher("1");
-        } catch (UnsupportedOperationException e) {
-            exCount++;
-        }
-        assertEquals(2, exCount);
+        assertEquals(1, exCount);
 
         assertNull(STATIC_CTX.getServletRegistration("1"));
     }
@@ -230,6 +220,12 @@ public class AwsServletContextTest {
         assertNotNull(ctx.getServlet("srv1"));
         assertNotNull(ctx.getServletRegistration("srv1"));
         assertEquals("", ((TestServlet)ctx.getServlet("srv1")).getId());
+    }
+
+    @Test
+    void getNamedDispatcher_returnsDispatcher() {
+        AwsServletContext ctx = new AwsServletContext(null);
+        assertNotNull(ctx.getNamedDispatcher("/hello"));
     }
 
     public static class TestServlet implements Servlet {


### PR DESCRIPTION
*Description of changes:*

Implements ServletContext.getNamedDispatcher so it forwards to the correct servlet

Fixes #499

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.