### PR TITLE
fix: Use the correct content-type for serving JS and CSS

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContext.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContext.java
@@ -133,6 +133,12 @@ public class AwsServletContext
         if (s == null || !s.contains(".")) {
             return null;
         }
+        if (s.endsWith(".css")) {
+            return "text/css";
+        }
+        if (s.endsWith(".js")) {
+            return "application/javascript";
+        }
         if (mimeTypes == null) {
             mimeTypes = new MimetypesFileTypeMap();
         }


### PR DESCRIPTION
*Description of changes:*

Especially JavaScript modules has a hard requirement on the content type being correct

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.