### PR TITLE
fix: Provide correct mime type for javascript and css

### DIFF
--- a/aws-serverless-java-container-core/pom.xml
+++ b/aws-serverless-java-container-core/pom.xml
@@ -71,11 +71,6 @@
             <artifactId>commons-fileupload2</artifactId>
             <version>2.0-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.angus</groupId>
-            <artifactId>angus-mail</artifactId>
-            <version>2.0.1</version>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContext.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContext.java
@@ -167,7 +167,12 @@ public class AwsServletContext
         if (mimeTypes == null) {
             mimeTypes = new MimetypesFileTypeMap();
         }
-
+        if (s.endsWith(".css")) {
+                return "text/css";
+        }
+        if (s.endsWith(".js")) {
+                return "application/javascript";
+        }
         // TODO: The getContentType method of the MimetypesFileTypeMap returns application/octet-stream
         // instead of null when the type cannot be found. We should replace with an implementation that
         // loads the System mime types ($JAVA_HOME/lib/mime.types

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContext.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContext.java
@@ -17,23 +17,25 @@ import com.amazonaws.serverless.proxy.internal.LambdaContainerHandler;
 import com.amazonaws.serverless.proxy.internal.SecurityUtils;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import jakarta.activation.spi.MimeTypeRegistryProvider;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.*;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.descriptor.JspConfigDescriptor;
-import jakarta.activation.MimetypesFileTypeMap;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Paths;
 import java.util.*;
-import java.util.stream.Collectors;
 
 
 /**
@@ -61,7 +63,6 @@ public class AwsServletContext
     private Map<String, String> initParameters;
     private AwsLambdaServletContainerHandler containerHandler;
     private Logger log = LoggerFactory.getLogger(AwsServletContext.class);
-    private MimetypesFileTypeMap mimeTypes; // lazily loaded in the getMimeType method
 
 
     //-------------------------------------------------------------
@@ -166,22 +167,16 @@ public class AwsServletContext
             return null;
         }
 
-        // this implementation would be nice but returns null on Lambda
-//        try {
-//            mimeType = Files.probeContentType(Paths.get(file));
-//        } catch (IOException | InvalidPathException e) {
-//            log("unable to probe for content type, will use fallback", e);
-//        }
+        String mimeType = null;
 
-        if (mimeTypes == null) {
-            mimeTypes = new MimetypesFileTypeMap();
+        // may not work on Lambda until mailcap package is present https://github.com/awslabs/aws-serverless-java-container/pull/504
+        try {
+            mimeType = Files.probeContentType(Paths.get(file));
+        } catch (IOException | InvalidPathException e) {
+            log("unable to probe for content type, will use fallback", e);
         }
-        String mimeType = mimeTypes.getContentType(file);
 
-        // The getContentType method of the MimetypesFileTypeMap
-        // returns MimetypesFileTypeMap.defaultType = application/octet-stream
-        // instead of null when the type cannot be found. trying to improve the result...
-        if (mimeType == null || MediaType.APPLICATION_OCTET_STREAM.equals(mimeType)) {
+        if (mimeType == null) {
             try {
                 String mimeTypeGuess = URLConnection.guessContentTypeFromName(new File(file).getName());
                 if (mimeTypeGuess !=null) {

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContextTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContextTest.java
@@ -65,6 +65,13 @@ public class AwsServletContextTest {
         mimeType = ctx.getMimeType("file://" + tmpFilePath);
         assertEquals("text/plain", mimeType);
     }
+    @Test
+    void getMimeType_mimeTypeOfJavascript_expectApplicationJavascript() {
+        String tmpFilePath = TMP_DIR + "some.js";
+        AwsServletContext ctx = new AwsServletContext(null);
+        String mimeType = ctx.getMimeType(tmpFilePath);
+        assertEquals("application/javascript", mimeType);
+    }
 
     @Test
     void getMimeType_unknownExtension_expectAppOctetStream() {

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContextTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContextTest.java
@@ -70,7 +70,7 @@ public class AwsServletContextTest {
         String tmpFilePath = TMP_DIR + "some.js";
         AwsServletContext ctx = new AwsServletContext(null);
         String mimeType = ctx.getMimeType(tmpFilePath);
-        assertEquals("application/javascript", mimeType);
+        assertEquals("text/javascript", mimeType);
     }
 
     @Test

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContextTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContextTest.java
@@ -74,10 +74,10 @@ public class AwsServletContextTest {
     }
 
     @Test
-    void getMimeType_unknownExtension_expectAppOctetStream() {
+    void getMimeType_unknownExtension_expectNull() {
         AwsServletContext ctx = new AwsServletContext(null);
         String mimeType = ctx.getMimeType("myfile.unkext");
-        assertEquals("application/octet-stream", mimeType);
+        assertNull(mimeType);
     }
 
 


### PR DESCRIPTION
The correct mimetype for javascript is a requirement when loading javascript modules