### PR TITLE
gh-511 Support Accept-Language header values containing country subtag

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2ProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2ProxyHttpServletRequest.java
@@ -408,31 +408,13 @@ public class AwsHttpApiV2ProxyHttpServletRequest extends AwsHttpServletRequest {
 
     @Override
     public Locale getLocale() {
-        // Accept-Language: fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5
-        List<HeaderValue> values = this.parseHeaderValue(
-                headers.getFirst(HttpHeaders.ACCEPT_LANGUAGE), ",", ";"
-        );
-        if (values.size() == 0) {
-            return Locale.getDefault();
-        }
-        return new Locale(values.get(0).getValue());
+        List<Locale> locales = parseAcceptLanguageHeader(headers.getFirst(HttpHeaders.ACCEPT_LANGUAGE));
+        return locales.size() == 0 ? Locale.getDefault() : locales.get(0);
     }
 
     @Override
     public Enumeration<Locale> getLocales() {
-        List<HeaderValue> values = this.parseHeaderValue(
-                headers.getFirst(HttpHeaders.ACCEPT_LANGUAGE), ",", ";"
-        );
-
-        List<Locale> locales = new ArrayList<>();
-        if (values.size() == 0) {
-            locales.add(Locale.getDefault());
-        } else {
-            for (HeaderValue locale : values) {
-                locales.add(new Locale(locale.getValue()));
-            }
-        }
-
+        List<Locale> locales = parseAcceptLanguageHeader(headers.getFirst(HttpHeaders.ACCEPT_LANGUAGE));
         return Collections.enumeration(locales);
     }
 

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
@@ -20,7 +20,6 @@ import com.amazonaws.serverless.proxy.model.ContainerConfig;
 import com.amazonaws.serverless.proxy.model.Headers;
 import com.amazonaws.serverless.proxy.model.RequestSource;
 import com.amazonaws.services.lambda.runtime.Context;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +28,6 @@ import javax.servlet.*;
 import javax.servlet.http.*;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.SecurityContext;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
@@ -38,15 +36,7 @@ import java.security.Principal;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -471,35 +461,15 @@ public class AwsProxyHttpServletRequest extends AwsHttpServletRequest {
 
     @Override
     public Locale getLocale() {
-        // Accept-Language: fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5
-        List<HeaderValue> values = this.parseHeaderValue(
-                request.getMultiValueHeaders().getFirst(HttpHeaders.ACCEPT_LANGUAGE), ",", ";"
-        );
-        if (values.size() == 0) {
-            return Locale.getDefault();
-        }
-        return new Locale(values.get(0).getValue());
+        List<Locale> locales = parseAcceptLanguageHeader(request.getMultiValueHeaders().getFirst(HttpHeaders.ACCEPT_LANGUAGE));
+        return locales.size() == 0 ? Locale.getDefault() : locales.get(0);
     }
-
 
     @Override
     public Enumeration<Locale> getLocales() {
-        List<HeaderValue> values = this.parseHeaderValue(
-                request.getMultiValueHeaders().getFirst(HttpHeaders.ACCEPT_LANGUAGE), ",", ";"
-        );
-
-        List<Locale> locales = new ArrayList<>();
-        if (values.size() == 0) {
-            locales.add(Locale.getDefault());
-        } else {
-            for (HeaderValue locale : values) {
-                locales.add(new Locale(locale.getValue()));
-            }
-        }
-
+        List<Locale> locales = parseAcceptLanguageHeader(request.getMultiValueHeaders().getFirst(HttpHeaders.ACCEPT_LANGUAGE));
         return Collections.enumeration(locales);
     }
-
 
     @Override
     public boolean isSecure() {

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestTest.java
@@ -501,7 +501,7 @@ public class AwsProxyHttpServletRequestTest {
         int localesNo = 0;
         while (locales.hasMoreElements()) {
             Locale defaultLocale = locales.nextElement();
-            assertEquals(new Locale("fr-CH"), defaultLocale);
+            assertEquals(new Locale("fr", "CH"), defaultLocale);
             localesNo++;
         }
         assertEquals(1, localesNo);
@@ -512,7 +512,7 @@ public class AwsProxyHttpServletRequestTest {
     void getLocales_validAcceptHeaderMultipleLocales_expectFullLocaleList(String type) {
         initAwsProxyHttpServletRequestTest(type);
         AwsProxyRequestBuilder req = getRequestWithHeaders();
-        req.header(HttpHeaders.ACCEPT_LANGUAGE, "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5");
+        req.header(HttpHeaders.ACCEPT_LANGUAGE, "fr-CA, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5");
         HttpServletRequest servletRequest = getRequest(req, null, null);
         Enumeration<Locale> locales = servletRequest.getLocales();
         List<Locale> localesList = new ArrayList<>();
@@ -520,14 +520,14 @@ public class AwsProxyHttpServletRequestTest {
             localesList.add(locales.nextElement());
         }
         assertEquals(5, localesList.size());
-        assertEquals(new Locale("fr-CH"), localesList.get(0));
-        assertEquals(new Locale("fr"), localesList.get(1));
-        assertEquals(new Locale("en"), localesList.get(2));
+        assertEquals(Locale.CANADA_FRENCH, localesList.get(0));
+        assertEquals(Locale.FRENCH, localesList.get(1));
+        assertEquals(Locale.ENGLISH, localesList.get(2));
         assertEquals(new Locale("de"), localesList.get(3));
         assertEquals(new Locale("*"), localesList.get(4));
 
         assertNotNull(servletRequest.getLocale());
-        assertEquals(new Locale("fr-CH"), servletRequest.getLocale());
+        assertEquals(Locale.CANADA_FRENCH, servletRequest.getLocale());
     }
 
     @MethodSource("data")
@@ -535,7 +535,7 @@ public class AwsProxyHttpServletRequestTest {
     void getLocales_validAcceptHeaderMultipleLocales_expectFullLocaleListOrdered(String type) {
         initAwsProxyHttpServletRequestTest(type);
         AwsProxyRequestBuilder req = getRequestWithHeaders();
-        req.header(HttpHeaders.ACCEPT_LANGUAGE, "fr-CH, en;q=0.8, de;q=0.7, *;q=0.5, fr;q=0.9");
+        req.header(HttpHeaders.ACCEPT_LANGUAGE, "fr-CA, en;q=0.8, de;q=0.7, *;q=0.5, fr;q=0.9");
         HttpServletRequest servletRequest = getRequest(req, null, null);
         Enumeration<Locale> locales = servletRequest.getLocales();
         List<Locale> localesList = new ArrayList<>();
@@ -543,9 +543,9 @@ public class AwsProxyHttpServletRequestTest {
             localesList.add(locales.nextElement());
         }
         assertEquals(5, localesList.size());
-        assertEquals(new Locale("fr-CH"), localesList.get(0));
-        assertEquals(new Locale("fr"), localesList.get(1));
-        assertEquals(new Locale("en"), localesList.get(2));
+        assertEquals(Locale.CANADA_FRENCH, localesList.get(0));
+        assertEquals(Locale.FRENCH, localesList.get(1));
+        assertEquals(Locale.ENGLISH, localesList.get(2));
         assertEquals(new Locale("de"), localesList.get(3));
         assertEquals(new Locale("*"), localesList.get(4));
     }


### PR DESCRIPTION
*Issue #, if available:* #511

*Description of changes:*

Support `Accept-Language` header values which also contain a country part. 

Unlike mentioned in the GH issue, I did not use `Locale#forLanguageTag` to parse the language tag because it looks like invalid / unknown language tags result in an "empty" `Locale` object which I think might cause undesired side effects. 


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.