### PR TITLE
Load using the application class loader

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContext.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsServletContext.java
@@ -519,9 +519,7 @@ public class AwsServletContext
 
     @Override
     public ClassLoader getClassLoader() {
-        // for the time being we return the default class loader. We may want to let developers override this int the
-        // future.
-        return ClassLoader.getSystemClassLoader();
+        return getClass().getClassLoader();
     }
 
 


### PR DESCRIPTION
By using the class loader from the servlet context to load the servlet class, the servlet class will be able to find its resources from the class path.

Fixes #506


By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.