### PR TITLE
Remove commons-fileupload

### DIFF
--- a/aws-serverless-java-container-core/pom.xml
+++ b/aws-serverless-java-container-core/pom.xml
@@ -67,9 +67,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-fileupload2</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
         </dependency>
 
         <dependency>

--- a/aws-serverless-java-container-core/pom.xml
+++ b/aws-serverless-java-container-core/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
+            <version>2.12.0</version>
         </dependency>
 
         <dependency>

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
@@ -22,11 +22,6 @@ import com.amazonaws.serverless.proxy.model.Headers;
 import com.amazonaws.serverless.proxy.model.MultiValuedTreeMap;
 import com.amazonaws.services.lambda.runtime.Context;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.apache.commons.fileupload2.FileItem;
-import org.apache.commons.fileupload2.FileUploadException;
-import org.apache.commons.fileupload2.disk.DiskFileItemFactory;
-import org.apache.commons.fileupload2.jaksrvlt.JakSrvltFileUpload;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.NullInputStream;
 import org.slf4j.Logger;
@@ -508,39 +503,7 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
 
     @SuppressFBWarnings({"FILE_UPLOAD_FILENAME", "WEAK_FILENAMEUTILS"})
     protected Map<String, Part> getMultipartFormParametersMap() {
-        if (multipartFormParameters != null) {
-            return multipartFormParameters;
-        }
-        if (!JakSrvltFileUpload.isMultipartContent(this)) { // isMultipartContent also checks the content type
-            multipartFormParameters = new HashMap<>();
-            return multipartFormParameters;
-        }
-        Timer.start("SERVLET_REQUEST_GET_MULTIPART_PARAMS");
-        multipartFormParameters = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-
-        JakSrvltFileUpload upload = new JakSrvltFileUpload(new DiskFileItemFactory());
-
-        try {
-            List<FileItem> items = upload.parseRequest(this);
-            for (FileItem item : items) {
-                String fileName = FilenameUtils.getName(item.getName());
-                AwsProxyRequestPart newPart = new AwsProxyRequestPart(item.get());
-                newPart.setName(item.getFieldName());
-                newPart.setSubmittedFileName(fileName);
-                newPart.setContentType(item.getContentType());
-                newPart.setSize(item.getSize());
-                item.getHeaders().getHeaderNames().forEachRemaining(h -> {
-                    newPart.addHeader(h, item.getHeaders().getHeader(h));
-                });
-
-                multipartFormParameters.put(item.getFieldName(), newPart);
-            }
-        } catch (FileUploadException e) {
-            Timer.stop("SERVLET_REQUEST_GET_MULTIPART_PARAMS");
-            log.error("Could not read multipart upload file", e);
-        }
-        Timer.stop("SERVLET_REQUEST_GET_MULTIPART_PARAMS");
-        return multipartFormParameters;
+        throw new UnsupportedOperationException();
     }
 
     protected String[] getQueryParamValues(MultiValuedTreeMap<String, String> qs, String key, boolean isCaseSensitive) {

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestFormTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestFormTest.java
@@ -7,7 +7,8 @@ import com.amazonaws.serverless.proxy.internal.testutils.AwsProxyRequestBuilder;
 import org.apache.commons.io.IOUtils;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.ServletException;
@@ -51,6 +52,7 @@ public class AwsProxyHttpServletRequestFormTest {
                                                                                   .build();
     private static final String ENCODED_FORM_ENTITY = PART_KEY_1 + "=" + ENCODED_VALUE + "&" + PART_KEY_2 + "=" + PART_VALUE_2;
 
+    @Disabled("Disabled until new release of commons-fileupload based on Jakarta APIs")
     @Test
     void postForm_getParam_getEncodedFullValue() {
         try {
@@ -67,6 +69,7 @@ public class AwsProxyHttpServletRequestFormTest {
         }
     }
 
+    @Disabled("Disabled until new release of commons-fileupload based on Jakarta APIs")
     @Test
     void postForm_getParts_parsing() {
         try {
@@ -86,6 +89,7 @@ public class AwsProxyHttpServletRequestFormTest {
         }
     }
 
+    @Disabled("Disabled until new release of commons-fileupload based on Jakarta APIs")
     @Test
     void multipart_getParts_binary() {
         try {

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/testutils/AwsProxyRequestBuilder.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/testutils/AwsProxyRequestBuilder.java
@@ -155,12 +155,7 @@ public class AwsProxyRequestBuilder {
     }
 
     public AwsProxyRequestBuilder formFilePart(String fieldName, String fileName, byte[] content) throws IOException {
-        if (multipartBuilder == null) {
-            multipartBuilder = MultipartEntityBuilder.create();
-        }
-        multipartBuilder.addPart(fieldName, new ByteArrayBody(content, fileName));
-        buildMultipartBody();
-        return this;
+        throw new UnsupportedOperationException();
     }
 
     public AwsProxyRequestBuilder formTextFieldPart(String fieldName, String fieldValue)

--- a/aws-serverless-java-container-jersey/src/test/java/com/amazonaws/serverless/proxy/jersey/JerseyParamEncodingTest.java
+++ b/aws-serverless-java-container-jersey/src/test/java/com/amazonaws/serverless/proxy/jersey/JerseyParamEncodingTest.java
@@ -263,6 +263,7 @@ public class JerseyParamEncodingTest {
         validateSingleValueModel(resp, "3");
     }
 
+    @Disabled("Disabled until new release of commons-fileupload based on Jakarta APIs")
     @MethodSource("data")
     @ParameterizedTest
     void multipart_getFileSize_expectCorrectLength(String reqType)

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/SpringAwsProxyTest.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/SpringAwsProxyTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.web.servlet.DispatcherServlet;
@@ -468,6 +469,7 @@ public class SpringAwsProxyTest {
         SpringLambdaContainerHandler.getContainerConfig().setUseStageAsServletContext(false);
     }
 
+    @Disabled("Disabled until new release of commons-fileupload based on Jakarta APIs")
     @MethodSource("data")
     @ParameterizedTest
     void multipart_getFileName_returnsCorrectFileName(String reqType)

--- a/aws-serverless-java-container-struts/pom.xml
+++ b/aws-serverless-java-container-struts/pom.xml
@@ -94,11 +94,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency><!-- [CVE-2021-29425] commons-fileupload ships with 2.2 -->
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>2.11.0</version>
-            </dependency>
             <dependency><!-- [CVE-2022-42889] transitive dep via Struts -->
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removed the commons-fileupload while we wait for a new release based on Jakarta APIs.

By submitting this pull request

- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.