### PR TITLE
Superseded Symphonia Lambda-Logging con Lambda Powertools

### DIFF
--- a/samples/jersey/pet-store/build.gradle
+++ b/samples/jersey/pet-store/build.gradle
@@ -9,7 +9,7 @@ dependencies {
   implementation (
           'com.amazonaws.serverless:aws-serverless-java-container-jersey:[2.0-SNAPSHOT,)',
           'com.fasterxml.jackson.core:jackson-databind:2.15.0',
-          'io.symphonia:lambda-logging:1.0.3'
+          'software.amazon.lambda:powertools-logging:1.15.0'
   )
 
   implementation("org.glassfish.jersey.media:jersey-media-json-jackson:3.1.1") {

--- a/samples/jersey/pet-store/pom.xml
+++ b/samples/jersey/pet-store/pom.xml
@@ -75,11 +75,11 @@
             <version>${jackson.version}</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/io.symphonia/lambda-logging -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.lambda/powertools-logging -->
         <dependency>
-            <groupId>io.symphonia</groupId>
-            <artifactId>lambda-logging</artifactId>
-            <version>1.0.3</version>
+            <groupId>software.amazon.lambda</groupId>
+            <artifactId>powertools-logging</artifactId>
+            <version>1.15.0</version>
         </dependency>
 
     </dependencies>

--- a/samples/spark/pet-store/build.gradle
+++ b/samples/spark/pet-store/build.gradle
@@ -10,7 +10,7 @@ dependencies {
           'com.sparkjava:spark-core:2.9.4',
           'com.amazonaws.serverless:aws-serverless-java-container-spark:[1.0,)',
           'com.fasterxml.jackson.core:jackson-databind:2.15.0',
-          'io.symphonia:lambda-logging:1.0.3'
+          'software.amazon.lambda:powertools-logging:1.15.0'
   )
 }
 

--- a/samples/spark/pet-store/pom.xml
+++ b/samples/spark/pet-store/pom.xml
@@ -51,11 +51,11 @@
             <version>${jackson.version}</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/io.symphonia/lambda-logging -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.lambda/powertools-logging -->
         <dependency>
-            <groupId>io.symphonia</groupId>
-            <artifactId>lambda-logging</artifactId>
-            <version>1.0.3</version>
+            <groupId>software.amazon.lambda</groupId>
+            <artifactId>powertools-logging</artifactId>
+            <version>1.15.0</version>
         </dependency>
     </dependencies>
 

--- a/samples/springboot3/pet-store/build.gradle
+++ b/samples/springboot3/pet-store/build.gradle
@@ -12,7 +12,7 @@ dependencies {
             exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
           },
           'com.amazonaws.serverless:aws-serverless-java-container-springboot3:[2.0-SNAPSHOT,)',
-          'io.symphonia:lambda-logging:1.0.3'
+          'software.amazon.lambda:powertools-logging:1.15.0'
   )
   testImplementation("junit:junit")
 }

--- a/samples/springboot3/pet-store/pom.xml
+++ b/samples/springboot3/pet-store/pom.xml
@@ -46,11 +46,11 @@
             <version>[2.0-SNAPSHOT,)</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/io.symphonia/lambda-logging -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.lambda/powertools-logging -->
         <dependency>
-            <groupId>io.symphonia</groupId>
-            <artifactId>lambda-logging</artifactId>
-            <version>1.0.3</version>
+            <groupId>software.amazon.lambda</groupId>
+            <artifactId>powertools-logging</artifactId>
+            <version>1.15.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
*Issue:
#496 
*Description of changes:
Replace Symphonia Lambda-Logging with Lambda Powertools, 
the corresponding Symphonia Lambda-Logging dependencies were removed and in the same way log4j2.xml was made the necessary modifications, both in a previous merge in the main branch

By submitting this pull request

- [X ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X ] I confirm that I've made a best effort attempt to update all relevant documentation.