### PR TITLE
GH-577 Ensure listeners are notified after dispatch

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsAsyncContext.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsAsyncContext.java
@@ -74,8 +74,8 @@ public class AwsAsyncContext implements AsyncContext {
                 throw new IllegalStateException("Dispatching already started");
             }
             dispatched.set(true);
-            notifyListeners(NotificationType.START_ASYNC, null);
             handler.doFilter(req, res, ((AwsServletContext)req.getServletContext()).getServletForPath(req.getRequestURI()));
+            notifyListeners(NotificationType.START_ASYNC, null);
         } catch (ServletException | IOException e) {
             notifyListeners(NotificationType.ERROR, e);
         }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletResponse.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletResponse.java
@@ -322,6 +322,10 @@ public class AwsHttpServletResponse
                 }
             }
 
+            @Override
+            public void flush() throws IOException {
+                flushBuffer();
+            }
 
             @Override
             public void close()

--- a/aws-serverless-java-container-springboot3/src/test/java/com/amazonaws/serverless/proxy/spring/ServletAppTest.java
+++ b/aws-serverless-java-container-springboot3/src/test/java/com/amazonaws/serverless/proxy/spring/ServletAppTest.java
@@ -40,6 +40,17 @@ public class ServletAppTest {
 
     @MethodSource("data")
     @ParameterizedTest
+    void asyncRequest(String reqType) {
+        initServletAppTest(reqType);
+        AwsProxyRequestBuilder req = new AwsProxyRequestBuilder("/async", "POST")
+                .json()
+                .body("{\"name\":\"bob\"}");
+        AwsProxyResponse resp = handler.handleRequest(req, lambdaContext);
+        assertEquals("{\"name\":\"BOB\"}", resp.getBody());
+    }
+
+    @MethodSource("data")
+    @ParameterizedTest
     void helloRequest_respondsWithSingleMessage(String reqType) {
         initServletAppTest(reqType);
         AwsProxyRequestBuilder req = new AwsProxyRequestBuilder("/hello", "GET");

--- a/aws-serverless-java-container-springboot3/src/test/java/com/amazonaws/serverless/proxy/spring/servletapp/MessageController.java
+++ b/aws-serverless-java-container-springboot3/src/test/java/com/amazonaws/serverless/proxy/spring/servletapp/MessageController.java
@@ -5,9 +5,13 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.async.DeferredResult;
 import org.springframework.web.server.ResponseStatusException;
 
 import jakarta.validation.Valid;
+import reactor.core.publisher.Mono;
+
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -17,6 +21,22 @@ public class MessageController {
     public static final String VALID_MESSAGE = "VALID";
     public static final String UTF8_RESPONSE = "öüäß фрыцшщ";
     public static final String EX_MESSAGE = "404 exception message";
+
+
+    @RequestMapping(path="/hi", method=RequestMethod.GET, produces = {"text/plain"})
+    public Mono<String> hi() {
+        return Mono.just(HELLO_MESSAGE);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+	@RequestMapping(path = "/async", method = RequestMethod.POST)
+	@ResponseBody
+	public DeferredResult<Map<String, String>> asyncResult(@RequestBody Map<String, String> value) {
+		DeferredResult result = new DeferredResult<>();
+		result.setResult(Collections.singletonMap("name", value.get("name").toUpperCase()));
+		return result;
+	}
+
 
     @RequestMapping(path="/hello", method=RequestMethod.GET, produces = {"text/plain"})
     public String hello() {


### PR DESCRIPTION
Resolves #577

In `AwsAsyncContext` the listeners were notified too early effectively canceling the async context before the final dispatch.

This PR is rather trivial as it simply switches the order or operations.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.