### PR TITLE
Modify algorithm for parameter transformation logic

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
@@ -548,7 +548,11 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
     }
 
     protected String[] getQueryParamValues(MultiValuedTreeMap<String, String> qs, String key, boolean isCaseSensitive) {
-        return getQueryParamValuesAsList(qs, key, isCaseSensitive).toArray(new String[0]);
+        List<String> value = getQueryParamValuesAsList(qs, key, isCaseSensitive);
+        if (value == null){
+            return null;
+        }
+        return value.toArray(new String[0]);
     }
 
     protected List<String> getQueryParamValuesAsList(MultiValuedTreeMap<String, String> qs, String key, boolean isCaseSensitive) {
@@ -564,7 +568,7 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
             }
         }
 
-        return new ArrayList<String>();
+        return Collections.emptyList();
     }
 
     protected Map<String, String[]> generateParameterMap(MultiValuedTreeMap<String, String> qs, ContainerConfig config) {


### PR DESCRIPTION
*Issue #, if available:* #573

*Description of changes:*
Change the way that the parameters are transformed between API GW event and the Servlet request to avoid race condition when using parallel processing while using a HashMap object. Adding a ConcurrentHashMap will likely cause too big of a latency increase, so we move the parallel processing to earlier in the algorithm, and keep the rest simpler.

I added a few comments in the code to make it easier to understand.

We can have a broader discussion about this, and I didn't add any extra test cases. (but I wanted to submit this PR before going on vacation for 10 days)

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.