### PR TITLE
Fix typos in FilterChainManager comments

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainManager.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/FilterChainManager.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 /**
- * This object in in charge of matching a servlet request to a set of filter, creating the filter chain for a request,
+ * This object is in charge of matching a servlet request to a set of filters, creating the filter chain for a request,
  * and cache filter chains that were already loaded for re-use. This object should be used by the framework-specific
  * implementations that use the <code>HttpServletRequest</code> and <code>HttpServletResponse</code> objects.
  *


### PR DESCRIPTION
Fixed minor typographical errors in the Javadoc comments of FilterChainManager.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request

- [v] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [v] I confirm that I've made a best effort attempt to update all relevant documentation.