### PR TITLE
Deprecate async init

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/ServletLambdaContainerHandlerBuilder.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/ServletLambdaContainerHandlerBuilder.java
@@ -92,7 +92,7 @@ public abstract class ServletLambdaContainerHandlerBuilder<
      * @return A populated builder
      */
     public Builder defaultProxy() {
-        initializationWrapper(new InitializationWrapper())
+        initializationWrapper(new AsyncInitializationWrapper())
                 .requestReader((RequestReader<RequestType, ContainerRequestType>) new AwsProxyHttpServletRequestReader())
                 .responseWriter((ResponseWriter<AwsHttpServletResponse, ResponseType>) new AwsProxyHttpServletResponseWriter())
                 .securityContextWriter((SecurityContextWriter<RequestType>) new AwsProxySecurityContextWriter())
@@ -108,7 +108,7 @@ public abstract class ServletLambdaContainerHandlerBuilder<
      * @return A populated builder
      */
     public Builder defaultHttpApiV2Proxy() {
-        initializationWrapper(new InitializationWrapper())
+        initializationWrapper(new AsyncInitializationWrapper())
                 .requestReader((RequestReader<RequestType, ContainerRequestType>) new AwsHttpApiV2HttpServletRequestReader())
                 .responseWriter((ResponseWriter<AwsHttpServletResponse, ResponseType>) new AwsProxyHttpServletResponseWriter(true))
                 .securityContextWriter((SecurityContextWriter<RequestType>) new AwsHttpApiV2SecurityContextWriter())
@@ -165,7 +165,7 @@ public abstract class ServletLambdaContainerHandlerBuilder<
     /**
      * Uses an async initializer with the given start time to calculate the 10 seconds timeout.
      *
-     * @deprecated As of release 1.5 this method is deprecated in favor of the parameters-less one {@link ServletLambdaContainerHandlerBuilder#asyncInit()}.
+     * @deprecated As of release 2.1 this method is deprecated. Initializer is always async if running in on-demand.
      * @param actualStartTime An epoch in milliseconds that should be used to calculate the 10 seconds timeout since the start of the application
      * @return A builder configured to use the async initializer
      */
@@ -178,6 +178,7 @@ public abstract class ServletLambdaContainerHandlerBuilder<
     /**
      * Uses a new {@link AsyncInitializationWrapper} with the no-parameter constructor that takes the actual JVM
      * start time
+     * @deprecated As of release 2.1 this method is deprecated. Initializer is always async if running in on-demand.
      * @return A builder configured to use an async initializer
      */
     public Builder asyncInit() {

--- a/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/springslowapp/LambdaHandler.java
+++ b/aws-serverless-java-container-spring/src/test/java/com/amazonaws/serverless/proxy/spring/springslowapp/LambdaHandler.java
@@ -18,7 +18,6 @@ public class LambdaHandler implements RequestHandler<AwsProxyRequest, AwsProxyRe
         long startTime = Instant.now().toEpochMilli();
         handler = new SpringProxyHandlerBuilder<AwsProxyRequest>()
                 .defaultProxy()
-                .asyncInit()
                 .configurationClasses(SlowAppConfig.class)
                 .buildAndInitialize();
         constructorTime = Instant.now().toEpochMilli() - startTime;

--- a/aws-serverless-java-container-springboot3/src/test/java/com/amazonaws/serverless/proxy/spring/slowapp/LambdaHandler.java
+++ b/aws-serverless-java-container-springboot3/src/test/java/com/amazonaws/serverless/proxy/spring/slowapp/LambdaHandler.java
@@ -21,7 +21,6 @@ public class LambdaHandler implements RequestHandler<AwsProxyRequest, AwsProxyRe
             System.out.println("startCall: " + startTime);
             handler = new SpringBootProxyHandlerBuilder<AwsProxyRequest>()
                     .defaultProxy()
-                    .asyncInit()
                     .springBootApplication(SlowTestApplication.class)
                     .buildAndInitialize();
             constructorTime = Instant.now().toEpochMilli() - startTime;

--- a/aws-serverless-springboot3-archetype/src/main/resources/archetype-resources/src/main/java/StreamLambdaHandler.java
+++ b/aws-serverless-springboot3-archetype/src/main/resources/archetype-resources/src/main/java/StreamLambdaHandler.java
@@ -18,12 +18,6 @@ public class StreamLambdaHandler implements RequestStreamHandler {
     static {
         try {
             handler = SpringBootLambdaContainerHandler.getAwsProxyHandler(Application.class);
-            // For applications that take longer than 10 seconds to start, use the async builder:
-            // handler = new SpringBootProxyHandlerBuilder<AwsProxyRequest>()
-            //                    .defaultProxy()
-            //                    .asyncInit()
-            //                    .springBootApplication(Application.class)
-            //                    .buildAndInitialize();
         } catch (ContainerInitializationException e) {
             // if we fail here. We re-throw the exception to force another cold start
             e.printStackTrace();

--- a/samples/springboot3/pet-store/src/main/java/com/amazonaws/serverless/sample/springboot3/StreamLambdaHandler.java
+++ b/samples/springboot3/pet-store/src/main/java/com/amazonaws/serverless/sample/springboot3/StreamLambdaHandler.java
@@ -25,13 +25,6 @@ public class StreamLambdaHandler implements RequestStreamHandler {
         try {
             handler = SpringBootLambdaContainerHandler.getAwsProxyHandler(Application.class);
 
-            // For applications that take longer than 10 seconds to start, use the async builder:
-            // handler = new SpringBootProxyHandlerBuilder<AwsProxyRequest>()
-            //                    .defaultProxy()
-            //                    .asyncInit()
-            //                    .springBootApplication(Application.class)
-            //                    .buildAndInitialize();
-
             // we use the onStartup method of the handler to register our custom filter
             handler.onStartup(servletContext -> {
                 FilterRegistration.Dynamic registration = servletContext.addFilter("CognitoIdentityFilter", CognitoIdentityFilter.class);


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/awslabs/aws-serverless-java-container/issues/507

*Description of changes:*
`asyncInit()` setting is now deprecated and always enabled unless users opt out by providing their own `initializationWrapper`. It's more sensible to provide a working default (that users can opt out of) than have a broken default depending on available resources and init times.

AsyncInitializationWrapper also falls back to InitializationWrapper if initialization mode is not "on-demand" to account for other execution modes (SnapStart and PC)

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.