### PR TITLE
Fix: Multipart files processing when Array of files with same fieldName is sent in request

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2ProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2ProxyHttpServletRequest.java
@@ -236,25 +236,6 @@ public class AwsHttpApiV2ProxyHttpServletRequest extends AwsHttpServletRequest {
     }
 
     @Override
-    public Collection<Part> getParts() throws IOException, ServletException {
-        List<Part> partList =
-                getMultipartFormParametersMap().values().stream()
-                        .flatMap(List::stream)
-                        .collect(Collectors.toList());
-        return partList;
-    }
-
-    @Override
-    public Part getPart(String s) throws IOException, ServletException {
-        // In case there's multiple files with the same fieldName, we return the first one in the list
-        List<Part> values = getMultipartFormParametersMap().get(s);
-        if (Objects.isNull(values)) {
-            return null;
-        }
-        return getMultipartFormParametersMap().get(s).get(0);
-    }
-
-    @Override
     public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass) throws IOException, ServletException {
         throw new UnsupportedOperationException();
     }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2ProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpApiV2ProxyHttpServletRequest.java
@@ -37,6 +37,7 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class AwsHttpApiV2ProxyHttpServletRequest extends AwsHttpServletRequest {
@@ -236,12 +237,21 @@ public class AwsHttpApiV2ProxyHttpServletRequest extends AwsHttpServletRequest {
 
     @Override
     public Collection<Part> getParts() throws IOException, ServletException {
-        return getMultipartFormParametersMap().values();
+        List<Part> partList =
+                getMultipartFormParametersMap().values().stream()
+                        .flatMap(List::stream)
+                        .collect(Collectors.toList());
+        return partList;
     }
 
     @Override
     public Part getPart(String s) throws IOException, ServletException {
-        return getMultipartFormParametersMap().get(s);
+        // In case there's multiple files with the same fieldName, we return the first one in the list
+        List<Part> values = getMultipartFormParametersMap().get(s);
+        if (Objects.isNull(values)) {
+            return null;
+        }
+        return getMultipartFormParametersMap().get(s).get(0);
     }
 
     @Override

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
@@ -86,7 +86,7 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
     private ServletContext servletContext;
     private AwsHttpSession session;
     private String queryString;
-    private Map<String, Part> multipartFormParameters;
+    private Map<String, List<Part>> multipartFormParameters;
     private Map<String, List<String>> urlEncodedFormParameters;
 
     protected AwsHttpServletResponse response;
@@ -511,7 +511,7 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
     }
 
     @SuppressFBWarnings({"FILE_UPLOAD_FILENAME", "WEAK_FILENAMEUTILS"})
-    protected Map<String, Part> getMultipartFormParametersMap() {
+    protected Map<String, List<Part>> getMultipartFormParametersMap() {
         if (multipartFormParameters != null) {
             return multipartFormParameters;
         }
@@ -537,7 +537,7 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
                     newPart.addHeader(h, item.getHeaders().getHeader(h));
                 });
 
-                multipartFormParameters.put(item.getFieldName(), newPart);
+                addPart(multipartFormParameters, item.getFieldName(), newPart);
             }
         } catch (FileUploadException e) {
             Timer.stop("SERVLET_REQUEST_GET_MULTIPART_PARAMS");
@@ -545,6 +545,14 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
         }
         Timer.stop("SERVLET_REQUEST_GET_MULTIPART_PARAMS");
         return multipartFormParameters;
+    }
+    private void addPart(Map<String, List<Part>> params, String fieldName, Part newPart) {
+        List<Part> partList = params.get(fieldName);
+        if (Objects.isNull(partList)) {
+            partList = new ArrayList<>();
+            params.put(fieldName, partList);
+        }
+        partList.add(newPart);
     }
 
     protected String[] getQueryParamValues(MultiValuedTreeMap<String, String> qs, String key, boolean isCaseSensitive) {

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
@@ -510,6 +510,27 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
         return urlEncodedFormParameters;
     }
 
+    @Override
+    public Collection<Part> getParts()
+            throws IOException, ServletException {
+        List<Part> partList =
+                getMultipartFormParametersMap().values().stream()
+                        .flatMap(List::stream)
+                        .collect(Collectors.toList());
+        return partList;
+    }
+
+    @Override
+    public Part getPart(String s)
+            throws IOException, ServletException {
+        // In case there's multiple files with the same fieldName, we return the first one in the list
+        List<Part> values = getMultipartFormParametersMap().get(s);
+        if (Objects.isNull(values)) {
+            return null;
+        }
+        return getMultipartFormParametersMap().get(s).get(0);
+    }
+
     @SuppressFBWarnings({"FILE_UPLOAD_FILENAME", "WEAK_FILENAMEUTILS"})
     protected Map<String, List<Part>> getMultipartFormParametersMap() {
         if (multipartFormParameters != null) {

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
@@ -259,14 +259,23 @@ public class AwsProxyHttpServletRequest extends AwsHttpServletRequest {
     @Override
     public Collection<Part> getParts()
             throws IOException, ServletException {
-        return getMultipartFormParametersMap().values();
+        List<Part> partList =
+                getMultipartFormParametersMap().values().stream()
+                        .flatMap(List::stream)
+                        .collect(Collectors.toList());
+        return partList;
     }
 
 
     @Override
     public Part getPart(String s)
             throws IOException, ServletException {
-        return getMultipartFormParametersMap().get(s);
+        // In case there's multiple files with the same fieldName, we return the first one in the list
+        List<Part> values = getMultipartFormParametersMap().get(s);
+        if (Objects.isNull(values)) {
+            return null;
+        }
+        return getMultipartFormParametersMap().get(s).get(0);
     }
 
 

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
@@ -255,30 +255,6 @@ public class AwsProxyHttpServletRequest extends AwsHttpServletRequest {
         throw new UnsupportedOperationException();
     }
 
-
-    @Override
-    public Collection<Part> getParts()
-            throws IOException, ServletException {
-        List<Part> partList =
-                getMultipartFormParametersMap().values().stream()
-                        .flatMap(List::stream)
-                        .collect(Collectors.toList());
-        return partList;
-    }
-
-
-    @Override
-    public Part getPart(String s)
-            throws IOException, ServletException {
-        // In case there's multiple files with the same fieldName, we return the first one in the list
-        List<Part> values = getMultipartFormParametersMap().get(s);
-        if (Objects.isNull(values)) {
-            return null;
-        }
-        return getMultipartFormParametersMap().get(s).get(0);
-    }
-
-
     @Override
     public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass)
             throws IOException, ServletException {


### PR DESCRIPTION
*Issue #, if available:* #633

*Description of changes:*

Fixed Multipart files processing issue occurring when Array of files with same fieldName is sent in the request.


By submitting this pull request

- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.